### PR TITLE
feat: fitness ui redesign

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+	"permissions": {
+		"allow": [
+			"Bash(ls /Users/glennsheppard/Development/Personal/synapse/src/routes/\\\\\\(app\\\\\\)/fitness/workouts/)",
+			"Bash(ls /Users/glennsheppard/Development/Personal/synapse/src/routes/\\\\\\(app\\\\\\)/fitness/weight/)",
+			"Bash(ls /Users/glennsheppard/Development/Personal/synapse/src/routes/\\\\\\(app\\\\\\)/fitness/meals/)",
+			"Bash(grep -r \"from-green\\\\|to-emerald\\\\|bg-gradient\" /Users/glennsheppard/Development/Personal/synapse/src --include=*.svelte -l)",
+			"Bash(npm run:*)",
+			"Bash(grep -v \"^$\")",
+			"Bash(npx biome:*)"
+		]
+	}
+}

--- a/src/lib/components/fitness/analytics/WorkoutFrequencyChart.svelte
+++ b/src/lib/components/fitness/analytics/WorkoutFrequencyChart.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+import { BarChart } from 'layerchart';
+
+import * as Card from '$lib/components/ui/card';
+import * as Chart from '$lib/components/ui/chart';
+
+interface Workout {
+	id: string;
+	date: string;
+	type: string;
+}
+
+let { workouts }: { workouts: Workout[] } = $props();
+
+const chartConfig = {
+	strength: { label: 'Strength', color: 'var(--chart-1)' },
+	cardio: { label: 'Cardio', color: 'var(--chart-2)' },
+	yoga: { label: 'Yoga', color: 'var(--chart-4)' },
+	other: { label: 'Other', color: 'var(--chart-3)' }
+} satisfies Chart.ChartConfig;
+
+// Build last 8 weeks of data
+const chartData = $derived.by(() => {
+	const weeks: { label: string; startDate: Date }[] = [];
+	const now = new Date();
+
+	for (let i = 7; i >= 0; i--) {
+		const start = new Date(now);
+		// Monday-aligned weeks
+		start.setDate(now.getDate() - ((now.getDay() + 6) % 7) - i * 7);
+		start.setHours(0, 0, 0, 0);
+		const label = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+		weeks.push({ label, startDate: start });
+	}
+
+	return weeks.map(({ label, startDate }, _i) => {
+		const endDate = new Date(startDate);
+		endDate.setDate(startDate.getDate() + 7);
+
+		const weekWorkouts = workouts.filter((w) => {
+			const d = new Date(w.date);
+			return d >= startDate && d < endDate;
+		});
+
+		return {
+			week: label,
+			strength: weekWorkouts.filter((w) => w.type === 'strength').length,
+			cardio: weekWorkouts.filter((w) => w.type === 'cardio').length,
+			yoga: weekWorkouts.filter((w) => w.type === 'yoga').length,
+			other: weekWorkouts.filter((w) => w.type === 'other').length,
+			total: weekWorkouts.length
+		};
+	});
+});
+
+const totalThisWeek = $derived(chartData[chartData.length - 1]?.total ?? 0);
+
+// Consecutive weeks with at least one workout
+const weeklyStreak = $derived.by(() => {
+	let streak = 0;
+	for (let i = chartData.length - 1; i >= 0; i--) {
+		if (chartData[i].total > 0) {
+			streak++;
+		} else {
+			break;
+		}
+	}
+	return streak;
+});
+</script>
+
+<Card.Root>
+	<Card.Header>
+		<Card.Title class="font-display">Weekly Frequency</Card.Title>
+		<Card.Description>Workouts per week over the last 8 weeks</Card.Description>
+	</Card.Header>
+	<Card.Content>
+		{#if workouts.length === 0}
+			<div
+				class="flex h-48 items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground"
+			>
+				Log workouts to see your weekly frequency
+			</div>
+		{:else}
+			<Chart.Container config={chartConfig} class="h-48 w-full">
+				<BarChart
+					data={chartData}
+					x="week"
+					series={[
+						{ key: 'strength', label: 'Strength', color: chartConfig.strength.color },
+						{ key: 'cardio', label: 'Cardio', color: chartConfig.cardio.color },
+						{ key: 'yoga', label: 'Yoga', color: chartConfig.yoga.color },
+						{ key: 'other', label: 'Other', color: chartConfig.other.color }
+					]}
+					seriesLayout="stack"
+					props={{
+						xAxis: {
+							format: (v: string) => v
+						}
+					}}
+				>
+					{#snippet tooltip()}
+						<Chart.Tooltip indicator="dot" />
+					{/snippet}
+				</BarChart>
+			</Chart.Container>
+		{/if}
+	</Card.Content>
+	<Card.Footer class="flex justify-between border-t pt-4 text-sm text-muted-foreground">
+		<span>This week: <span class="font-medium text-foreground">{totalThisWeek}</span></span>
+		<span>
+			Weekly streak: <span class="font-medium text-foreground">{weeklyStreak}</span>
+			{weeklyStreak === 1 ? 'week' : 'weeks'}
+		</span>
+	</Card.Footer>
+</Card.Root>

--- a/src/lib/components/fitness/analytics/WorkoutStatsBar.svelte
+++ b/src/lib/components/fitness/analytics/WorkoutStatsBar.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+import ClockIcon from '@lucide/svelte/icons/clock';
+import DumbbellIcon from '@lucide/svelte/icons/dumbbell';
+import FlameIcon from '@lucide/svelte/icons/flame';
+import TrendingUpIcon from '@lucide/svelte/icons/trending-up';
+
+interface Workout {
+	id: string;
+	date: string;
+	durationMinutes: number | null;
+}
+
+let { workouts }: { workouts: Workout[] } = $props();
+
+const stats = $derived.by(() => {
+	const now = new Date();
+	const thirtyDaysAgo = new Date(now);
+	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+	const last30 = workouts.filter((w) => new Date(w.date) >= thirtyDaysAgo);
+
+	// This week (Mon–Sun)
+	const startOfWeek = new Date(now);
+	startOfWeek.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+	startOfWeek.setHours(0, 0, 0, 0);
+	const thisWeek = workouts.filter((w) => new Date(w.date) >= startOfWeek);
+
+	// Current streak: consecutive days with at least one workout
+	const workoutDates = new Set(workouts.map((w) => w.date));
+	let streak = 0;
+	const d = new Date(now);
+	d.setHours(0, 0, 0, 0);
+	while (true) {
+		const dateStr = d.toISOString().slice(0, 10);
+		if (workoutDates.has(dateStr)) {
+			streak++;
+			d.setDate(d.getDate() - 1);
+		} else {
+			break;
+		}
+	}
+
+	const longestSession = workouts.reduce((max, w) => Math.max(max, w.durationMinutes ?? 0), 0);
+
+	return {
+		last30Count: last30.length,
+		thisWeekCount: thisWeek.length,
+		streak,
+		longestSession
+	};
+});
+
+const cards = $derived([
+	{
+		label: 'Last 30 Days',
+		value: stats.last30Count,
+		unit: 'workouts',
+		icon: DumbbellIcon
+	},
+	{
+		label: 'This Week',
+		value: stats.thisWeekCount,
+		unit: 'workouts',
+		icon: TrendingUpIcon
+	},
+	{
+		label: 'Day Streak',
+		value: stats.streak,
+		unit: 'days',
+		icon: FlameIcon
+	},
+	{
+		label: 'Longest Session',
+		value: stats.longestSession,
+		unit: 'min',
+		icon: ClockIcon
+	}
+]);
+</script>
+
+<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+	{#each cards as card (card.label)}
+		<div
+			class="flex flex-col gap-1 rounded-xl bg-linear-to-br from-green-500 to-emerald-600 p-4 text-white"
+		>
+			<div class="flex items-center justify-between">
+				<p class="text-xs font-medium uppercase tracking-wide text-white/70">{card.label}</p>
+				<card.icon class="h-4 w-4 text-white/60" />
+			</div>
+			<p class="font-display text-3xl font-bold leading-none">{card.value}</p>
+			<p class="text-xs text-white/70">{card.unit}</p>
+		</div>
+	{/each}
+</div>

--- a/src/lib/components/fitness/dialogs/CreateReminderDialog.svelte
+++ b/src/lib/components/fitness/dialogs/CreateReminderDialog.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+import BellPlusIcon from '@lucide/svelte/icons/bell-plus';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import * as Select from '$lib/components/ui/select';
+import type { workoutReminderSchema } from '$lib/schemas/fitness';
+import { daysOfWeek } from '$lib/utils/date';
+
+type WorkoutReminderData = Infer<typeof workoutReminderSchema>;
+
+let { formData }: { formData: SuperValidated<WorkoutReminderData> } = $props();
+
+let open = $state(false);
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	resetForm: true,
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			toast.success('Reminder created successfully!');
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error creating reminder: ${result.error.message}`);
+	}
+});
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			<Button {...props} class="bg-green-600 text-white hover:bg-green-700">
+				<BellPlusIcon class="mr-2 h-4 w-4" />
+				Add Reminder
+			</Button>
+		{/snippet}
+	</Dialog.Trigger>
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>Schedule Workout Reminder</Dialog.Title>
+			<Dialog.Description
+				>Get email reminders to stay consistent with your routine</Dialog.Description
+			>
+		</Dialog.Header>
+		<form method="POST" action="?/createReminder" use:enhance>
+			<div class="grid gap-4 py-4">
+				<div class="grid grid-cols-2 gap-4">
+					<div class="grid gap-2">
+						<Label for="r-workoutType">Workout Type</Label>
+						<Select.Root type="single" name="workoutType" bind:value={$form.workoutType}>
+							<Select.Trigger id="r-workoutType">
+								{$form.workoutType || 'Select type'}
+							</Select.Trigger>
+							<Select.Content>
+								<Select.Item value="strength" label="Strength">Strength</Select.Item>
+								<Select.Item value="cardio" label="Cardio">Cardio</Select.Item>
+								<Select.Item value="yoga" label="Yoga">Yoga</Select.Item>
+								<Select.Item value="other" label="Other">Other</Select.Item>
+							</Select.Content>
+						</Select.Root>
+						{#if $errors.workoutType}
+							<p class="text-sm text-destructive">{$errors.workoutType}</p>
+						{/if}
+					</div>
+					<div class="grid gap-2">
+						<Label for="r-time">Time</Label>
+						<Input id="r-time" name="time" type="time" bind:value={$form.time} required />
+						{#if $errors.time}
+							<p class="text-sm text-destructive">{$errors.time}</p>
+						{/if}
+					</div>
+				</div>
+
+				<div class="grid gap-2">
+					<Label for="r-cadence">Frequency</Label>
+					<Select.Root type="single" name="cadence" bind:value={$form.cadence}>
+						<Select.Trigger id="r-cadence"> {$form.cadence || 'Select frequency'} </Select.Trigger>
+						<Select.Content>
+							<Select.Item value="daily" label="Daily">Daily</Select.Item>
+							<Select.Item value="weekly" label="Weekly">Weekly</Select.Item>
+						</Select.Content>
+					</Select.Root>
+					{#if $errors.cadence}
+						<p class="text-sm text-destructive">{$errors.cadence}</p>
+					{/if}
+				</div>
+
+				{#if $form.cadence === 'weekly'}
+					<div class="grid gap-2">
+						<Label>Days of Week</Label>
+						<Input
+							id="r-daysOfWeek"
+							name="daysOfWeek"
+							type="text"
+							bind:value={$form.daysOfWeek}
+							hidden
+						/>
+						<div class="flex flex-wrap gap-2">
+							{#each daysOfWeek as day (day.id)}
+								{@const selectedDays = $form.daysOfWeek ? JSON.parse($form.daysOfWeek) : []}
+								<Button
+									type="button"
+									variant={selectedDays.includes(day.id) ? 'default' : 'outline'}
+									size="sm"
+									onclick={() => {
+										const days = $form.daysOfWeek ? JSON.parse($form.daysOfWeek) : [];
+										if (days.includes(day.id)) {
+											$form.daysOfWeek = JSON.stringify(days.filter((d: number) => d !== day.id));
+										} else {
+											$form.daysOfWeek = JSON.stringify([...days, day.id].sort());
+										}
+									}}
+								>
+									{day.shortName}
+								</Button>
+							{/each}
+						</div>
+						{#if $errors.daysOfWeek}
+							<p class="text-sm text-destructive">{$errors.daysOfWeek}</p>
+						{/if}
+					</div>
+				{/if}
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">
+					Create Reminder
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/dialogs/LogMealDialog.svelte
+++ b/src/lib/components/fitness/dialogs/LogMealDialog.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+import PlusIcon from '@lucide/svelte/icons/plus';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import LongTextInput from '$lib/components/shared/LongTextInput.svelte';
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import * as Select from '$lib/components/ui/select';
+import type { logMealSchema, MealType } from '$lib/schemas/fitness';
+
+type LogMealData = Infer<typeof logMealSchema>;
+
+interface EditMeal {
+	id: string;
+	date: string;
+	timeOfDay: string;
+	description: string;
+	caloriesEstimate: number | null;
+}
+
+let {
+	formData,
+	editEntry = null,
+	onClose
+}: {
+	formData: SuperValidated<LogMealData>;
+	editEntry?: EditMeal | null;
+	onClose?: () => void;
+} = $props();
+
+const isEditing = $derived(editEntry !== null);
+
+let open = $state(false);
+
+// Open dialog externally when editEntry is provided
+$effect(() => {
+	if (editEntry) {
+		open = true;
+	}
+});
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	resetForm: !isEditing,
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			toast.success(isEditing ? 'Meal updated successfully!' : 'Meal logged successfully!');
+			onClose?.();
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error: ${result.error.message}`);
+	}
+});
+
+// Populate form fields when editing
+$effect(() => {
+	if (editEntry) {
+		$form.date = editEntry.date;
+		$form.timeOfDay = editEntry.timeOfDay as MealType;
+		$form.description = editEntry.description;
+		$form.caloriesEstimate = editEntry.caloriesEstimate;
+	}
+});
+
+function handleOpenChange(isOpen: boolean) {
+	open = isOpen;
+	if (!isOpen) {
+		onClose?.();
+	}
+}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	{#if !isEditing}
+		<Dialog.Trigger>
+			{#snippet child({ props })}
+				<Button {...props} class="bg-green-600 text-white hover:bg-green-700">
+					<PlusIcon class="mr-2 h-4 w-4" />
+					Log Meal
+				</Button>
+			{/snippet}
+		</Dialog.Trigger>
+	{/if}
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>{isEditing ? 'Edit Meal' : 'Log Meal'}</Dialog.Title>
+			<Dialog.Description>
+				{isEditing ? 'Update your meal entry' : 'Record what you ate'}
+			</Dialog.Description>
+		</Dialog.Header>
+		<form method="POST" action={isEditing ? '?/updateMeal' : '?/logMeal'} use:enhance>
+			{#if isEditing && editEntry}
+				<input type="hidden" name="id" value={editEntry.id}>
+			{/if}
+			<div class="grid gap-4 py-4">
+				<div class="grid gap-2">
+					<Label for="meal-date">Date</Label>
+					<Input id="meal-date" name="date" type="date" bind:value={$form.date} required />
+					{#if $errors.date}
+						<p class="text-sm text-destructive">{$errors.date}</p>
+					{/if}
+				</div>
+				<div class="grid gap-2">
+					<Label for="meal-type">Meal Type</Label>
+					<Select.Root type="single" name="timeOfDay" bind:value={$form.timeOfDay}>
+						<Select.Trigger id="meal-type">
+							{$form.timeOfDay || 'Select meal type'}
+						</Select.Trigger>
+						<Select.Content>
+							<Select.Item value="breakfast" label="Breakfast">Breakfast</Select.Item>
+							<Select.Item value="lunch" label="Lunch">Lunch</Select.Item>
+							<Select.Item value="dinner" label="Dinner">Dinner</Select.Item>
+							<Select.Item value="snack" label="Snack">Snack</Select.Item>
+						</Select.Content>
+					</Select.Root>
+					{#if $errors.timeOfDay}
+						<p class="text-sm text-destructive">{$errors.timeOfDay}</p>
+					{/if}
+				</div>
+				<div class="grid gap-2">
+					<Label for="meal-description">Description</Label>
+					<LongTextInput
+						id="meal-description"
+						name="description"
+						bind:value={$form.description}
+						rows={3}
+						placeholder="e.g., Chicken salad with olive oil dressing"
+						required
+					/>
+					{#if $errors.description}
+						<p class="text-sm text-destructive">{$errors.description}</p>
+					{/if}
+				</div>
+				<div class="grid gap-2">
+					<Label for="meal-calories">Calories (estimate)</Label>
+					<Input
+						id="meal-calories"
+						name="caloriesEstimate"
+						type="number"
+						bind:value={$form.caloriesEstimate}
+						placeholder="500"
+					/>
+					{#if $errors.caloriesEstimate}
+						<p class="text-sm text-destructive">{$errors.caloriesEstimate}</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">
+					{isEditing ? 'Save Changes' : 'Log Meal'}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/dialogs/LogWeightDialog.svelte
+++ b/src/lib/components/fitness/dialogs/LogWeightDialog.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+import PlusIcon from '@lucide/svelte/icons/plus';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import type { logWeightSchema } from '$lib/schemas/fitness';
+
+type LogWeightData = Infer<typeof logWeightSchema>;
+
+interface WeightEntry {
+	id: string;
+	date: string;
+	time: string | null;
+	weightLbs: number;
+}
+
+let {
+	formData,
+	editEntry = null,
+	onClose
+}: {
+	formData: SuperValidated<LogWeightData>;
+	editEntry?: WeightEntry | null;
+	onClose?: () => void;
+} = $props();
+
+const isEditing = $derived(editEntry !== null);
+
+let open = $state(false);
+
+// Open dialog externally when editEntry is provided
+$effect(() => {
+	if (editEntry) {
+		open = true;
+	}
+});
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	resetForm: !isEditing,
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			toast.success(isEditing ? 'Weight updated successfully!' : 'Weight logged successfully!');
+			onClose?.();
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error: ${result.error.message}`);
+	}
+});
+
+// Populate form fields when editing
+$effect(() => {
+	if (editEntry) {
+		$form.date = editEntry.date;
+		$form.time = editEntry.time;
+		$form.weightLbs = editEntry.weightLbs;
+	}
+});
+
+function handleOpenChange(isOpen: boolean) {
+	open = isOpen;
+	if (!isOpen) {
+		onClose?.();
+	}
+}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	{#if !isEditing}
+		<Dialog.Trigger>
+			{#snippet child({ props })}
+				<Button {...props} class="bg-green-600 text-white hover:bg-green-700">
+					<PlusIcon class="mr-2 h-4 w-4" />
+					Log Weight
+				</Button>
+			{/snippet}
+		</Dialog.Trigger>
+	{/if}
+	<Dialog.Content class="sm:max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>{isEditing ? 'Edit Weight Entry' : 'Log Weight'}</Dialog.Title>
+			<Dialog.Description>
+				{isEditing ? 'Update your weight entry' : 'Record your current weight'}
+			</Dialog.Description>
+		</Dialog.Header>
+		<form method="POST" action={isEditing ? '?/updateWeight' : '?/logWeight'} use:enhance>
+			{#if isEditing && editEntry}
+				<input type="hidden" name="id" value={editEntry.id}>
+			{/if}
+			<div class="grid gap-4 py-4">
+				<div class="grid gap-2">
+					<Label for="weight-date">Date</Label>
+					<Input id="weight-date" name="date" type="date" bind:value={$form.date} required />
+					{#if $errors.date}
+						<p class="text-sm text-destructive">{$errors.date}</p>
+					{/if}
+				</div>
+				<div class="grid gap-2">
+					<Label for="weight-time">Time (optional)</Label>
+					<Input id="weight-time" name="time" type="time" bind:value={$form.time} />
+					{#if $errors.time}
+						<p class="text-sm text-destructive">{$errors.time}</p>
+					{/if}
+				</div>
+				<div class="grid gap-2">
+					<Label for="weight-lbs">Weight (lbs)</Label>
+					<Input
+						id="weight-lbs"
+						name="weightLbs"
+						type="number"
+						step="0.1"
+						bind:value={$form.weightLbs}
+						placeholder="150.0"
+						required
+					/>
+					{#if $errors.weightLbs}
+						<p class="text-sm text-destructive">{$errors.weightLbs}</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">
+					{isEditing ? 'Save Changes' : 'Log Weight'}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/dialogs/LogWorkoutDialog.svelte
+++ b/src/lib/components/fitness/dialogs/LogWorkoutDialog.svelte
@@ -1,0 +1,221 @@
+<script lang="ts">
+import PlusIcon from '@lucide/svelte/icons/plus';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import ExerciseInput from '$lib/components/fitness/ExerciseInput.svelte';
+import LongTextInput from '$lib/components/shared/LongTextInput.svelte';
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import * as Select from '$lib/components/ui/select';
+import type { logWorkoutSchema, WorkoutType } from '$lib/schemas/fitness';
+import type { Exercise } from '$lib/types';
+import { getTodayString } from '$lib/utils/date';
+
+type LogWorkoutData = Infer<typeof logWorkoutSchema>;
+
+interface WorkoutExercise {
+	exerciseName: string;
+	sets: number | null;
+	reps: number | null;
+	weightLbs: number | null;
+}
+
+interface EditWorkout {
+	id: string;
+	date: string;
+	time: string | null;
+	type: string;
+	durationMinutes: number | null;
+	notes: string | null;
+	exercises: WorkoutExercise[];
+}
+
+let {
+	formData,
+	editEntry = null,
+	onClose
+}: {
+	formData: SuperValidated<LogWorkoutData>;
+	editEntry?: EditWorkout | null;
+	onClose?: () => void;
+} = $props();
+
+const isEditing = $derived(editEntry !== null);
+
+let open = $state(false);
+let workoutExercises = $state<Exercise[]>([]);
+
+// Open dialog externally when editEntry is provided
+$effect(() => {
+	if (editEntry) {
+		open = true;
+	}
+});
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			workoutExercises = [];
+			toast.success(isEditing ? 'Workout updated successfully!' : 'Workout logged successfully!');
+			onClose?.();
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error: ${result.error.message}`);
+	}
+});
+
+$effect(() => {
+	if (workoutExercises.length > 0) {
+		$form.exercises = JSON.stringify(workoutExercises);
+	}
+});
+
+// Populate form fields when editing
+$effect(() => {
+	if (editEntry) {
+		$form.date = editEntry.date;
+		$form.time = editEntry.time;
+		$form.type = editEntry.type as WorkoutType;
+		$form.durationMinutes = editEntry.durationMinutes;
+		$form.notes = editEntry.notes;
+		if (editEntry.exercises && editEntry.exercises.length > 0) {
+			workoutExercises = editEntry.exercises.map((e) => ({
+				exerciseName: e.exerciseName,
+				sets: e.sets,
+				reps: e.reps,
+				weightLbs: e.weightLbs
+			}));
+		}
+	}
+});
+
+// Default the date to today when opening for new entry
+$effect(() => {
+	if (open && !isEditing && !$form.date) {
+		$form.date = getTodayString();
+	}
+});
+
+function handleOpenChange(isOpen: boolean) {
+	open = isOpen;
+	if (!isOpen) {
+		workoutExercises = [];
+		onClose?.();
+	}
+}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	{#if !isEditing}
+		<Dialog.Trigger>
+			{#snippet child({ props })}
+				<Button {...props} class="bg-green-600 text-white hover:bg-green-700">
+					<PlusIcon class="mr-2 h-4 w-4" />
+					Log Workout
+				</Button>
+			{/snippet}
+		</Dialog.Trigger>
+	{/if}
+	<Dialog.Content class="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+		<Dialog.Header>
+			<Dialog.Title>{isEditing ? 'Edit Workout' : 'Log Workout'}</Dialog.Title>
+			<Dialog.Description>
+				{isEditing ? 'Update your workout session' : 'Record your workout session'}
+			</Dialog.Description>
+		</Dialog.Header>
+		<form method="POST" action={isEditing ? '?/updateWorkout' : '?/logWorkout'} use:enhance>
+			{#if isEditing && editEntry}
+				<input type="hidden" name="id" value={editEntry.id}>
+			{/if}
+			<div class="grid gap-4 py-4">
+				<div class="grid grid-cols-2 gap-4">
+					<div class="grid gap-2">
+						<Label for="workout-date">Date</Label>
+						<Input id="workout-date" name="date" type="date" bind:value={$form.date} required />
+						{#if $errors.date}
+							<p class="text-sm text-destructive">{$errors.date}</p>
+						{/if}
+					</div>
+					<div class="grid gap-2">
+						<Label for="workout-time">Time (optional)</Label>
+						<Input id="workout-time" name="time" type="time" bind:value={$form.time} />
+						{#if $errors.time}
+							<p class="text-sm text-destructive">{$errors.time}</p>
+						{/if}
+					</div>
+				</div>
+
+				<div class="grid gap-2">
+					<Label for="workout-type">Workout Type</Label>
+					<Select.Root type="single" name="type" bind:value={$form.type}>
+						<Select.Trigger id="workout-type">
+							{$form.type || 'Select workout type'}
+						</Select.Trigger>
+						<Select.Content>
+							<Select.Item value="strength" label="Strength">Strength</Select.Item>
+							<Select.Item value="cardio" label="Cardio">Cardio</Select.Item>
+							<Select.Item value="yoga" label="Yoga">Yoga</Select.Item>
+							<Select.Item value="other" label="Other">Other</Select.Item>
+						</Select.Content>
+					</Select.Root>
+					{#if $errors.type}
+						<p class="text-sm text-destructive">{$errors.type}</p>
+					{/if}
+				</div>
+
+				<div class="grid gap-2">
+					<Label for="workout-duration">Duration (minutes)</Label>
+					<Input
+						id="workout-duration"
+						name="durationMinutes"
+						type="number"
+						bind:value={$form.durationMinutes}
+						placeholder="60"
+					/>
+					{#if $errors.durationMinutes}
+						<p class="text-sm text-destructive">{$errors.durationMinutes}</p>
+					{/if}
+				</div>
+
+				{#if $form.type === 'strength'}
+					<ExerciseInput bind:exercises={workoutExercises} />
+					<Input type="hidden" name="exercises" value={JSON.stringify(workoutExercises)} />
+					{#if $errors.exercises}
+						<p class="text-sm text-destructive">{$errors.exercises}</p>
+					{/if}
+				{/if}
+
+				<div class="grid gap-2">
+					<Label for="workout-notes">Notes (optional)</Label>
+					<LongTextInput
+						id="workout-notes"
+						name="notes"
+						bind:value={$form.notes}
+						rows={3}
+						placeholder="How did the workout feel?"
+					/>
+					{#if $errors.notes}
+						<p class="text-sm text-destructive">{$errors.notes}</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">
+					{isEditing ? 'Save Changes' : 'Log Workout'}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/dialogs/SetCalorieTargetDialog.svelte
+++ b/src/lib/components/fitness/dialogs/SetCalorieTargetDialog.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import SettingsIcon from '@lucide/svelte/icons/settings';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import type { setCalorieTargetSchema } from '$lib/schemas/fitness';
+
+type SetCalorieTargetData = Infer<typeof setCalorieTargetSchema>;
+
+let { formData }: { formData: SuperValidated<SetCalorieTargetData> } = $props();
+
+let open = $state(false);
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			toast.success('Calorie target set successfully!');
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error setting calorie target: ${result.error.message}`);
+	}
+});
+</script>
+
+<Tooltip.Root>
+	<Tooltip.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				type="button"
+				variant="ghost"
+				size="icon"
+				class="h-6 w-6 text-muted-foreground hover:text-foreground"
+				onclick={() => (open = true)}
+				aria-label="Set calorie target"
+			>
+				<SettingsIcon class="h-3.5 w-3.5" />
+			</Button>
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content>Set calorie target</Tooltip.Content>
+</Tooltip.Root>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="sm:max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Set Calorie Target</Dialog.Title>
+			<Dialog.Description>Define your daily calorie goal</Dialog.Description>
+		</Dialog.Header>
+		<form method="POST" action="?/setCalorieTarget" use:enhance>
+			<div class="grid gap-4 py-4">
+				<div class="grid gap-2">
+					<Label for="calorie-target">Daily Target (calories)</Label>
+					<Input
+						id="calorie-target"
+						name="targetCalories"
+						type="number"
+						bind:value={$form.targetCalories}
+						placeholder="2000"
+						required
+					/>
+					{#if $errors.targetCalories}
+						<p class="text-sm text-destructive">{$errors.targetCalories}</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">Set Target</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/dialogs/SetGoalWeightDialog.svelte
+++ b/src/lib/components/fitness/dialogs/SetGoalWeightDialog.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import TargetIcon from '@lucide/svelte/icons/target';
+import { toast } from 'svelte-sonner';
+import type { Infer, SuperValidated } from 'sveltekit-superforms';
+import { superForm } from 'sveltekit-superforms';
+
+import { Button } from '$lib/components/ui/button';
+import * as Dialog from '$lib/components/ui/dialog';
+import { Input } from '$lib/components/ui/input';
+import { Label } from '$lib/components/ui/label';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import type { setGoalWeightSchema } from '$lib/schemas/fitness';
+
+type SetGoalWeightData = Infer<typeof setGoalWeightSchema>;
+
+let { formData }: { formData: SuperValidated<SetGoalWeightData> } = $props();
+
+let open = $state(false);
+
+// svelte-ignore state_referenced_locally
+const { form, errors, enhance } = superForm(formData, {
+	onUpdate: ({ form }) => {
+		if (form.valid) {
+			open = false;
+			toast.success('Goal weight set successfully!');
+		}
+	},
+	onError: ({ result }) => {
+		toast.error(`Error setting goal weight: ${result.error.message}`);
+	}
+});
+</script>
+
+<Tooltip.Root>
+	<Tooltip.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				type="button"
+				variant="ghost"
+				size="icon"
+				class="h-6 w-6 text-muted-foreground hover:text-foreground"
+				onclick={() => (open = true)}
+				aria-label="Set goal weight"
+			>
+				<TargetIcon class="h-3.5 w-3.5" />
+			</Button>
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content>Set goal weight</Tooltip.Content>
+</Tooltip.Root>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="sm:max-w-sm">
+		<Dialog.Header>
+			<Dialog.Title>Set Goal Weight</Dialog.Title>
+			<Dialog.Description>Define your target weight goal</Dialog.Description>
+		</Dialog.Header>
+		<form method="POST" action="?/setGoal" use:enhance>
+			<div class="grid gap-4 py-4">
+				<div class="grid gap-2">
+					<Label for="goal-weight">Target Weight (lbs)</Label>
+					<Input
+						id="goal-weight"
+						name="targetWeightLbs"
+						type="number"
+						step="0.1"
+						bind:value={$form.targetWeightLbs}
+						placeholder="150.0"
+						required
+					/>
+					{#if $errors.targetWeightLbs}
+						<p class="text-sm text-destructive">{$errors.targetWeightLbs}</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Dialog.Close>
+					{#snippet child({ props })}
+						<Button {...props} type="button" variant="outline">Cancel</Button>
+					{/snippet}
+				</Dialog.Close>
+				<Button type="submit" class="bg-green-600 text-white hover:bg-green-700">Set Goal</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/fitness/entries/MealEntryCard.svelte
+++ b/src/lib/components/fitness/entries/MealEntryCard.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+import EditIcon from '@lucide/svelte/icons/edit';
+import Trash2Icon from '@lucide/svelte/icons/trash-2';
+
+import { Button } from '$lib/components/ui/button';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import { formatDateShort } from '$lib/utils/date';
+
+interface Meal {
+	id: string;
+	date: string;
+	timeOfDay: string;
+	description: string;
+	caloriesEstimate: number | null;
+}
+
+let {
+	meal,
+	onEdit,
+	onDelete
+}: {
+	meal: Meal;
+	onEdit: (meal: Meal) => void;
+	onDelete: (id: string) => void;
+} = $props();
+
+const mealIcons: Record<string, string> = {
+	breakfast: '🌅',
+	lunch: '☀️',
+	dinner: '🌙',
+	snack: '🍪'
+};
+
+const mealBadgeStyles: Record<string, string> = {
+	breakfast: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+	lunch: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+	dinner: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+	snack: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
+};
+
+const icon = $derived(mealIcons[meal.timeOfDay] ?? '🍽️');
+const badgeStyle = $derived(mealBadgeStyles[meal.timeOfDay] ?? '');
+</script>
+
+<div class="flex items-start justify-between gap-3 rounded-lg border bg-card p-3">
+	<div class="flex min-w-0 flex-1 items-start gap-3">
+		<span
+			class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm {badgeStyle}"
+			aria-hidden="true"
+		>
+			{icon}
+		</span>
+		<div class="min-w-0 flex-1">
+			<p class="line-clamp-2 text-sm">{meal.description}</p>
+			<p class="mt-0.5 text-xs text-muted-foreground capitalize">
+				{meal.timeOfDay}
+				· {formatDateShort(meal.date)}
+			</p>
+		</div>
+	</div>
+
+	<div class="flex shrink-0 items-center gap-2">
+		{#if meal.caloriesEstimate}
+			<div class="text-right">
+				<p class="font-display text-base font-bold text-green-600 dark:text-green-400">
+					{meal.caloriesEstimate}
+				</p>
+				<p class="text-xs text-muted-foreground">cal</p>
+			</div>
+		{/if}
+
+		<div class="flex items-center gap-1">
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="h-7 w-7"
+							onclick={() => onEdit(meal)}
+							aria-label="Edit meal"
+						>
+							<EditIcon class="h-3.5 w-3.5" />
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Edit</Tooltip.Content>
+			</Tooltip.Root>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+							onclick={() => onDelete(meal.id)}
+							aria-label="Delete meal"
+						>
+							<Trash2Icon class="h-3.5 w-3.5" />
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Delete</Tooltip.Content>
+			</Tooltip.Root>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/fitness/entries/ReminderCard.svelte
+++ b/src/lib/components/fitness/entries/ReminderCard.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+import BellIcon from '@lucide/svelte/icons/bell';
+import BellOffIcon from '@lucide/svelte/icons/bell-off';
+import Trash2Icon from '@lucide/svelte/icons/trash-2';
+
+import { Badge } from '$lib/components/ui/badge';
+import { Button } from '$lib/components/ui/button';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import { daysOfWeek, formatTime12Hour } from '$lib/utils/date';
+
+interface Reminder {
+	id: string;
+	workoutType: string;
+	cadence: string;
+	time: string;
+	daysOfWeek: string | null;
+	enabled: boolean;
+}
+
+let {
+	reminder,
+	onToggle,
+	onDelete
+}: {
+	reminder: Reminder;
+	onToggle: (reminder: Reminder) => void;
+	onDelete: (id: string) => void;
+} = $props();
+
+const typeStyles: Record<string, string> = {
+	strength: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+	cardio: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+	yoga: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+	other: 'bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-300'
+};
+
+const badgeStyle = $derived(typeStyles[reminder.workoutType] ?? typeStyles.other);
+
+const scheduleText = $derived(
+	reminder.cadence === 'daily'
+		? 'Every day'
+		: `Weekly on ${
+				reminder.daysOfWeek
+					? JSON.parse(reminder.daysOfWeek)
+							.map((d: number) => daysOfWeek[d].shortName)
+							.join(', ')
+					: 'Not configured'
+			}`
+);
+</script>
+
+<div
+	class="flex items-center justify-between rounded-lg border p-3 transition-colors"
+	class:opacity-60={!reminder.enabled}
+>
+	<div class="flex items-center gap-3">
+		<Badge class={badgeStyle}>{reminder.workoutType}</Badge>
+		<div>
+			<p class="text-sm font-medium">{formatTime12Hour(reminder.time)}</p>
+			<p class="text-xs text-muted-foreground">
+				{scheduleText}
+				{#if !reminder.enabled}
+					<span class="ml-1 text-muted-foreground">(Disabled)</span>
+				{/if}
+			</p>
+		</div>
+	</div>
+
+	<div class="flex items-center gap-1">
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						type="button"
+						variant="ghost"
+						size="icon"
+						class="h-7 w-7"
+						onclick={() => onToggle({ ...reminder, enabled: !reminder.enabled })}
+						aria-label={reminder.enabled ? 'Disable reminder' : 'Enable reminder'}
+					>
+						{#if reminder.enabled}
+							<BellOffIcon class="h-3.5 w-3.5" />
+						{:else}
+							<BellIcon class="h-3.5 w-3.5" />
+						{/if}
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>{reminder.enabled ? 'Disable' : 'Enable'}</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						type="button"
+						variant="ghost"
+						size="icon"
+						class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+						onclick={() => onDelete(reminder.id)}
+						aria-label="Delete reminder"
+					>
+						<Trash2Icon class="h-3.5 w-3.5" />
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Delete</Tooltip.Content>
+		</Tooltip.Root>
+	</div>
+</div>

--- a/src/lib/components/fitness/entries/WeightEntryCard.svelte
+++ b/src/lib/components/fitness/entries/WeightEntryCard.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+import EditIcon from '@lucide/svelte/icons/edit';
+import MinusIcon from '@lucide/svelte/icons/minus';
+import Trash2Icon from '@lucide/svelte/icons/trash-2';
+import TrendingDownIcon from '@lucide/svelte/icons/trending-down';
+import TrendingUpIcon from '@lucide/svelte/icons/trending-up';
+
+import { Button } from '$lib/components/ui/button';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import { formatDateShort, formatTime12Hour } from '$lib/utils/date';
+
+interface WeightEntry {
+	id: string;
+	date: string;
+	time: string | null;
+	weightLbs: number;
+}
+
+let {
+	entry,
+	previousEntry = null,
+	onEdit,
+	onDelete
+}: {
+	entry: WeightEntry;
+	previousEntry?: WeightEntry | null;
+	onEdit: (entry: WeightEntry) => void;
+	onDelete: (id: string) => void;
+} = $props();
+
+const delta = $derived(previousEntry != null ? entry.weightLbs - previousEntry.weightLbs : null);
+</script>
+
+<div
+	class="flex items-center justify-between rounded-lg border bg-green-50/30 p-3 dark:bg-green-950/20"
+>
+	<div class="flex items-center gap-4">
+		<div>
+			<p class="font-display text-xl font-bold">{entry.weightLbs} lbs</p>
+			<p class="text-xs text-muted-foreground">
+				{formatDateShort(entry.date)}
+				{#if entry.time}
+					@ {formatTime12Hour(entry.time)}
+				{/if}
+			</p>
+		</div>
+
+		{#if delta !== null}
+			<div class="flex items-center gap-1">
+				{#if delta < 0}
+					<TrendingDownIcon class="h-4 w-4 text-green-600" />
+					<span class="text-xs font-medium text-green-600">{Math.abs(delta).toFixed(1)} lbs</span>
+				{:else if delta > 0}
+					<TrendingUpIcon class="h-4 w-4 text-destructive" />
+					<span class="text-xs font-medium text-destructive">+{delta.toFixed(1)} lbs</span>
+				{:else}
+					<MinusIcon class="h-4 w-4 text-muted-foreground" />
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<div class="flex items-center gap-1">
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						type="button"
+						variant="ghost"
+						size="icon"
+						class="h-7 w-7"
+						onclick={() => onEdit(entry)}
+						aria-label="Edit weight entry"
+					>
+						<EditIcon class="h-3.5 w-3.5" />
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Edit</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						type="button"
+						variant="ghost"
+						size="icon"
+						class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+						onclick={() => onDelete(entry.id)}
+						aria-label="Delete weight entry"
+					>
+						<Trash2Icon class="h-3.5 w-3.5" />
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Delete</Tooltip.Content>
+		</Tooltip.Root>
+	</div>
+</div>

--- a/src/lib/components/fitness/entries/WorkoutEntryCard.svelte
+++ b/src/lib/components/fitness/entries/WorkoutEntryCard.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+import EditIcon from '@lucide/svelte/icons/edit';
+import Trash2Icon from '@lucide/svelte/icons/trash-2';
+
+import { Badge } from '$lib/components/ui/badge';
+import { Button } from '$lib/components/ui/button';
+import * as Tooltip from '$lib/components/ui/tooltip';
+import { formatDateMedium, formatTime12Hour } from '$lib/utils/date';
+
+interface Exercise {
+	exerciseName: string;
+	sets: number | null;
+	reps: number | null;
+	weightLbs: number | null;
+}
+
+interface Workout {
+	id: string;
+	date: string;
+	time: string | null;
+	type: string;
+	durationMinutes: number | null;
+	notes: string | null;
+	exercises: Exercise[];
+}
+
+let {
+	workout,
+	onEdit,
+	onDelete
+}: {
+	workout: Workout;
+	onEdit: (workout: Workout) => void;
+	onDelete: (id: string) => void;
+} = $props();
+
+let expanded = $state(false);
+
+const typeStyles: Record<string, { border: string; badge: string }> = {
+	strength: {
+		border: 'border-l-orange-500',
+		badge: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300'
+	},
+	cardio: {
+		border: 'border-l-blue-500',
+		badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+	},
+	yoga: {
+		border: 'border-l-purple-500',
+		badge: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
+	},
+	other: {
+		border: 'border-l-gray-400',
+		badge: 'bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-300'
+	}
+};
+
+const style = $derived(typeStyles[workout.type] ?? typeStyles.other);
+</script>
+
+<div
+	class="rounded-lg border border-l-4 bg-card p-3 transition-colors hover:bg-accent/30 {style.border}"
+>
+	<div class="flex items-start justify-between gap-2">
+		<div class="min-w-0 flex-1 space-y-1">
+			<div class="flex flex-wrap items-center gap-2">
+				<Badge class={style.badge}>{workout.type}</Badge>
+				{#if workout.durationMinutes}
+					<span class="text-xs text-muted-foreground">{workout.durationMinutes} min</span>
+				{/if}
+			</div>
+			<p class="text-xs text-muted-foreground">
+				{formatDateMedium(workout.date)}
+				{#if workout.time}
+					@ {formatTime12Hour(workout.time)}
+				{/if}
+			</p>
+			{#if workout.notes}
+				<p class="truncate text-xs text-muted-foreground">{workout.notes}</p>
+			{/if}
+
+			{#if workout.exercises && workout.exercises.length > 0}
+				<button
+					type="button"
+					class="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+					onclick={() => (expanded = !expanded)}
+				>
+					{#if expanded}
+						<ChevronDownIcon class="h-3 w-3" />
+					{:else}
+						<ChevronRightIcon class="h-3 w-3" />
+					{/if}
+					{workout.exercises.length}
+					{workout.exercises.length === 1 ? 'exercise' : 'exercises'}
+				</button>
+
+				{#if expanded}
+					<div class="mt-2 space-y-1 transition-all">
+						{#each workout.exercises as exercise (exercise.exerciseName)}
+							<div class="ml-4 text-xs text-muted-foreground">
+								• {exercise.exerciseName}
+								{#if exercise.sets || exercise.reps || exercise.weightLbs}
+									<span class="ml-1">
+										{#if exercise.sets}
+											{exercise.sets}s
+										{/if}
+										{#if exercise.reps}
+											× {exercise.reps}r
+										{/if}
+										{#if exercise.weightLbs}
+											@ {exercise.weightLbs}lb
+										{/if}
+									</span>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+		</div>
+
+		<div class="flex shrink-0 items-center gap-1">
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="h-7 w-7"
+							onclick={() => onEdit(workout)}
+							aria-label="Edit workout"
+						>
+							<EditIcon class="h-3.5 w-3.5" />
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Edit</Tooltip.Content>
+			</Tooltip.Root>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							type="button"
+							variant="ghost"
+							size="icon"
+							class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+							onclick={() => onDelete(workout.id)}
+							aria-label="Delete workout"
+						>
+							<Trash2Icon class="h-3.5 w-3.5" />
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Delete</Tooltip.Content>
+			</Tooltip.Root>
+		</div>
+	</div>
+</div>

--- a/src/routes/(app)/fitness/+page.server.ts
+++ b/src/routes/(app)/fitness/+page.server.ts
@@ -1,7 +1,8 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
+import { z } from 'zod';
 
 import {
 	deleteEntrySchema,
@@ -10,7 +11,11 @@ import {
 	logWorkoutSchema,
 	setCalorieTargetSchema,
 	setGoalWeightSchema,
+	updateMealSchema,
+	updateWeightSchema,
 	updateWorkoutReminderSchema,
+	updateWorkoutSchema,
+	workoutExerciseSchema,
 	workoutReminderSchema
 } from '$lib/schemas/fitness';
 import { requireAuth } from '$lib/server/actions/auth-guard';
@@ -20,6 +25,7 @@ import {
 	goalWeights,
 	mealLogs,
 	weightEntries,
+	workoutExercises,
 	workoutLogs,
 	workoutReminders
 } from '$lib/server/db/schema';
@@ -552,5 +558,253 @@ export const actions: Actions = {
 		}
 
 		throw redirect(303, '/fitness?tab=reminders&notice=reminder-deleted');
+	}),
+
+	updateWeight: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(updateWeightSchema));
+
+		if (!form.valid) {
+			return fail(400, { form });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.weightEntries.findFirst({
+				where: and(eq(weightEntries.id, form.data.id), eq(weightEntries.userId, user.id))
+			});
+
+			if (!existing) {
+				return message(form, { type: 'error', text: 'Weight entry not found.' }, { status: 404 });
+			}
+
+			await db
+				.update(weightEntries)
+				.set({
+					date: form.data.date,
+					time: form.data.time || null,
+					weightLbs: form.data.weightLbs,
+					updatedAt: new Date().toISOString()
+				})
+				.where(and(eq(weightEntries.id, form.data.id), eq(weightEntries.userId, user.id)));
+
+			logger.info('Weight entry updated', { entryId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to update weight entry', { error });
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to update weight entry. Please try again.' },
+				{ status: 500 }
+			);
+		}
+
+		return message(form, { type: 'success', text: 'Weight updated successfully!' });
+	}),
+
+	deleteWeight: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(deleteEntrySchema));
+
+		if (!form.valid) {
+			return fail(400, { error: 'Invalid weight entry id' });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.weightEntries.findFirst({
+				where: and(eq(weightEntries.id, form.data.id), eq(weightEntries.userId, user.id))
+			});
+
+			if (!existing) {
+				return fail(404, { error: 'Weight entry not found' });
+			}
+
+			await db
+				.delete(weightEntries)
+				.where(and(eq(weightEntries.id, form.data.id), eq(weightEntries.userId, user.id)));
+
+			logger.info('Weight entry deleted', { entryId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to delete weight entry', { error });
+			return fail(500, { error: 'Failed to delete weight entry' });
+		}
+
+		return { success: true };
+	}),
+
+	updateWorkout: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(updateWorkoutSchema));
+
+		if (!form.valid) {
+			return fail(400, { form });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.workoutLogs.findFirst({
+				where: and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id))
+			});
+
+			if (!existing) {
+				return message(form, { type: 'error', text: 'Workout not found.' }, { status: 404 });
+			}
+
+			const exercisesArraySchema = z.array(workoutExerciseSchema);
+			let parsedExercises: Array<z.infer<typeof workoutExerciseSchema>> = [];
+			if (form.data.type === 'strength' && form.data.exercises) {
+				try {
+					const exercisesInput = JSON.parse(form.data.exercises);
+					const parsed = exercisesArraySchema.safeParse(exercisesInput);
+					if (parsed.success) {
+						parsedExercises = parsed.data.filter(
+							(exercise) => exercise.exerciseName.trim().length > 0
+						);
+					}
+				} catch (parseError) {
+					logger.warn('Invalid exercises JSON during workout update', { error: parseError });
+				}
+			}
+
+			await db.transaction(async (tx) => {
+				await tx
+					.update(workoutLogs)
+					.set({
+						date: form.data.date,
+						time: form.data.time || null,
+						type: form.data.type,
+						durationMinutes: form.data.durationMinutes || null,
+						notes: form.data.notes || null,
+						updatedAt: new Date().toISOString()
+					})
+					.where(and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id)));
+
+				await tx.delete(workoutExercises).where(eq(workoutExercises.workoutLogId, form.data.id));
+
+				if (form.data.type === 'strength' && parsedExercises.length > 0) {
+					await tx.insert(workoutExercises).values(
+						parsedExercises.map((exercise) => ({
+							id: generateId(),
+							workoutLogId: form.data.id,
+							exerciseName: exercise.exerciseName,
+							sets: exercise.sets || null,
+							reps: exercise.reps || null,
+							weightLbs: exercise.weightLbs || null,
+							createdAt: new Date().toISOString(),
+							updatedAt: new Date().toISOString()
+						}))
+					);
+				}
+			});
+
+			logger.info('Workout updated', { workoutId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to update workout', { error });
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to update workout. Please try again.' },
+				{ status: 500 }
+			);
+		}
+
+		return message(form, { type: 'success', text: 'Workout updated successfully!' });
+	}),
+
+	deleteWorkout: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(deleteEntrySchema));
+
+		if (!form.valid) {
+			return fail(400, { error: 'Invalid workout id' });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.workoutLogs.findFirst({
+				where: and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id))
+			});
+
+			if (!existing) {
+				return fail(404, { error: 'Workout not found' });
+			}
+
+			await db
+				.delete(workoutLogs)
+				.where(and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id)));
+
+			logger.info('Workout deleted', { workoutId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to delete workout', { error });
+			return fail(500, { error: 'Failed to delete workout' });
+		}
+
+		return { success: true };
+	}),
+
+	updateMeal: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(updateMealSchema));
+
+		if (!form.valid) {
+			return fail(400, { form });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.mealLogs.findFirst({
+				where: and(eq(mealLogs.id, form.data.id), eq(mealLogs.userId, user.id))
+			});
+
+			if (!existing) {
+				return message(form, { type: 'error', text: 'Meal not found.' }, { status: 404 });
+			}
+
+			await db
+				.update(mealLogs)
+				.set({
+					date: form.data.date,
+					timeOfDay: form.data.timeOfDay,
+					description: form.data.description,
+					caloriesEstimate: form.data.caloriesEstimate || null,
+					updatedAt: new Date().toISOString()
+				})
+				.where(and(eq(mealLogs.id, form.data.id), eq(mealLogs.userId, user.id)));
+
+			logger.info('Meal updated', { mealId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to update meal', { error });
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to update meal. Please try again.' },
+				{ status: 500 }
+			);
+		}
+
+		return message(form, { type: 'success', text: 'Meal updated successfully!' });
+	}),
+
+	deleteMeal: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(deleteEntrySchema));
+
+		if (!form.valid) {
+			return fail(400, { error: 'Invalid meal id' });
+		}
+
+		try {
+			const db = getDb();
+			const existing = await db.query.mealLogs.findFirst({
+				where: and(eq(mealLogs.id, form.data.id), eq(mealLogs.userId, user.id))
+			});
+
+			if (!existing) {
+				return fail(404, { error: 'Meal not found' });
+			}
+
+			await db
+				.delete(mealLogs)
+				.where(and(eq(mealLogs.id, form.data.id), eq(mealLogs.userId, user.id)));
+
+			logger.info('Meal deleted', { mealId: form.data.id, userId: user.id });
+		} catch (error) {
+			logger.error('Failed to delete meal', { error });
+			return fail(500, { error: 'Failed to delete meal' });
+		}
+
+		return { success: true };
 	})
 };

--- a/src/routes/(app)/fitness/+page.svelte
+++ b/src/routes/(app)/fitness/+page.svelte
@@ -1,156 +1,44 @@
 <script lang="ts">
 import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
 import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
-import BellIcon from '@lucide/svelte/icons/bell';
-import BellOffIcon from '@lucide/svelte/icons/bell-off';
 import BellRingIcon from '@lucide/svelte/icons/bell-ring';
 import DumbbellIcon from '@lucide/svelte/icons/dumbbell';
-import Edit from '@lucide/svelte/icons/edit';
 import MinusIcon from '@lucide/svelte/icons/minus';
 import ScaleIcon from '@lucide/svelte/icons/scale';
 import TargetIcon from '@lucide/svelte/icons/target';
-import Trash2 from '@lucide/svelte/icons/trash-2';
 import TrendingDownIcon from '@lucide/svelte/icons/trending-down';
 import TrendingUpIcon from '@lucide/svelte/icons/trending-up';
 import UtensilsCrossedIcon from '@lucide/svelte/icons/utensils-crossed';
 import { SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
-import { superForm } from 'sveltekit-superforms';
 
 import { navigating, page } from '$app/state';
 import PageShell from '$lib/components/app/PageShell.svelte';
+import WorkoutFrequencyChart from '$lib/components/fitness/analytics/WorkoutFrequencyChart.svelte';
+import WorkoutStatsBar from '$lib/components/fitness/analytics/WorkoutStatsBar.svelte';
 import CalorieProgress from '$lib/components/fitness/CalorieProgress.svelte';
-import ExerciseInput from '$lib/components/fitness/ExerciseInput.svelte';
+import CreateReminderDialog from '$lib/components/fitness/dialogs/CreateReminderDialog.svelte';
+import LogMealDialog from '$lib/components/fitness/dialogs/LogMealDialog.svelte';
+import LogWeightDialog from '$lib/components/fitness/dialogs/LogWeightDialog.svelte';
+import LogWorkoutDialog from '$lib/components/fitness/dialogs/LogWorkoutDialog.svelte';
+import SetCalorieTargetDialog from '$lib/components/fitness/dialogs/SetCalorieTargetDialog.svelte';
+import SetGoalWeightDialog from '$lib/components/fitness/dialogs/SetGoalWeightDialog.svelte';
+import MealEntryCard from '$lib/components/fitness/entries/MealEntryCard.svelte';
+import ReminderCard from '$lib/components/fitness/entries/ReminderCard.svelte';
+import WeightEntryCard from '$lib/components/fitness/entries/WeightEntryCard.svelte';
+import WorkoutEntryCard from '$lib/components/fitness/entries/WorkoutEntryCard.svelte';
 import WeightChart from '$lib/components/fitness/WeightChart.svelte';
 import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
-import LongTextInput from '$lib/components/shared/LongTextInput.svelte';
 import PageSkeleton from '$lib/components/skeletons/PageSkeleton.svelte';
-import { Button } from '$lib/components/ui/button';
 import * as Card from '$lib/components/ui/card';
-import { Input } from '$lib/components/ui/input';
-import { Label } from '$lib/components/ui/label';
-import * as Select from '$lib/components/ui/select';
 import * as Tabs from '$lib/components/ui/tabs';
-import * as Tooltip from '$lib/components/ui/tooltip';
-import type { Exercise } from '$lib/types';
-import {
-	daysOfWeek,
-	formatDateMedium,
-	formatDateShort,
-	formatTime12Hour,
-	getTodayString
-} from '$lib/utils/date';
+import { getTodayString } from '$lib/utils/date';
 
 import type { PageData } from './$types.js';
 
 let { data }: { data: PageData } = $props();
 
-// svelte-ignore state_referenced_locally
-const {
-	form: weightForm,
-	errors: weightErrors,
-	enhance: weightEnhance,
-	message: weightMessage
-} = superForm(data.weightForm, {
-	resetForm: true,
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Weight logged successfully!');
-		}
-		if ($weightMessage?.type === 'error') {
-			toast.error(`Error logging weight. Reason: ${$weightMessage.text}`);
-		}
-	}
-});
-
-// svelte-ignore state_referenced_locally
-const {
-	form: workoutForm,
-	errors: workoutErrors,
-	enhance: workoutEnhance,
-	message: workoutMessage
-} = superForm(data.workoutForm, {
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Workout logged successfully!');
-		}
-		if ($workoutMessage?.type === 'error') {
-			toast.error(`Error logging workout. Reason: ${$workoutMessage.text}`);
-		}
-	}
-});
-
-// svelte-ignore state_referenced_locally
-const {
-	form: goalForm,
-	errors: goalErrors,
-	enhance: goalEnhance,
-	message: goalMessage
-} = superForm(data.goalForm, {
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Goal weight set successfully!');
-		}
-		if ($goalMessage?.type === 'error') {
-			toast.error(`Error setting goal weight. Reason: ${$goalMessage.text}`);
-		}
-	}
-});
-
-// svelte-ignore state_referenced_locally
-const {
-	form: mealForm,
-	errors: mealErrors,
-	enhance: mealEnhance,
-	message: mealMessage
-} = superForm(data.mealForm, {
-	resetForm: true,
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Meal logged successfully!');
-		}
-		if ($mealMessage?.type === 'error') {
-			toast.error(`Error logging meal. Reason: ${$mealMessage.text}`);
-		}
-	}
-});
-
-// svelte-ignore state_referenced_locally
-const {
-	form: calorieForm,
-	errors: calorieErrors,
-	enhance: calorieEnhance,
-	message: calorieMessage
-} = superForm(data.calorieForm, {
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Calorie target set successfully!');
-		}
-		if ($calorieMessage?.type === 'error') {
-			toast.error(`Error setting calorie target. Reason: ${$calorieMessage.text}`);
-		}
-	}
-});
-
-// svelte-ignore state_referenced_locally
-const {
-	form: reminderForm,
-	errors: reminderErrors,
-	enhance: reminderEnhance,
-	message: reminderMessage
-} = superForm(data.reminderForm, {
-	resetForm: true,
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Reminder saved successfully!');
-		}
-		if ($reminderMessage?.type === 'error') {
-			toast.error(`Error saving reminder. Reason: ${$reminderMessage.text}`);
-		}
-	}
-});
-
-let workoutExercises = $state<Exercise[]>([]);
+// Delete dialog state
 let weightEntryToDelete = $state<string | null>(null);
 let workoutToDelete = $state<string | null>(null);
 let mealToDelete = $state<string | null>(null);
@@ -159,15 +47,48 @@ let showDeleteWorkoutDialog = $state(false);
 let showDeleteMealDialog = $state(false);
 let reminderToDelete = $state<string | null>(null);
 let showDeleteReminderDialog = $state(false);
+
 let reminderToToggle = $state<{
 	id: string;
 	workoutType: string;
 	cadence: string;
 	time: string;
-	daysOfWeek: string;
+	daysOfWeek: string | null;
 	enabled: boolean;
 } | null>(null);
 let showToggleReminderDialog = $state(false);
+
+// Edit state
+let weightToEdit = $state<{
+	id: string;
+	date: string;
+	time: string | null;
+	weightLbs: number;
+} | null>(null);
+
+let workoutToEdit = $state<{
+	id: string;
+	date: string;
+	time: string | null;
+	type: string;
+	durationMinutes: number | null;
+	notes: string | null;
+	exercises: {
+		exerciseName: string;
+		sets: number | null;
+		reps: number | null;
+		weightLbs: number | null;
+	}[];
+} | null>(null);
+
+let mealToEdit = $state<{
+	id: string;
+	date: string;
+	timeOfDay: string;
+	description: string;
+	caloriesEstimate: number | null;
+} | null>(null);
+
 let activeTab = $state('workouts');
 const handledNotices = new SvelteSet<string>();
 
@@ -185,56 +106,42 @@ $effect(() => {
 	}
 
 	handledNotices.add(notice);
-	if (notice === 'weight-updated') {
-		toast.success('Weight entry updated successfully!');
-	} else if (notice === 'weight-deleted') {
-		toast.success('Weight entry deleted successfully!');
-	} else if (notice === 'workout-updated') {
-		toast.success('Workout updated successfully!');
-	} else if (notice === 'workout-deleted') {
-		toast.success('Workout deleted successfully!');
-	} else if (notice === 'meal-updated') {
-		toast.success('Meal updated successfully!');
-	} else if (notice === 'meal-deleted') {
-		toast.success('Meal deleted successfully!');
-	} else if (notice === 'reminder-disabled') {
+	if (notice === 'reminder-disabled') {
 		toast.success('Reminder disabled successfully!');
 	} else if (notice === 'reminder-deleted') {
 		toast.success('Reminder deleted successfully!');
 	}
 });
 
-// When form is valid, sync to hidden input
-$effect(() => {
-	if (workoutExercises.length > 0) {
-		$workoutForm.exercises = JSON.stringify(workoutExercises);
-	}
-});
-
-// Calculate today's total calories
-let todayTotalCalories = $derived.by(() => {
+const todayTotalCalories = $derived.by(() => {
 	const today = getTodayString();
-	const todayMeals = data.meals.filter((meal) => meal.date === today);
-	return todayMeals.reduce((sum, meal) => sum + (meal.caloriesEstimate || 0), 0);
+	return data.meals
+		.filter((meal) => meal.date === today)
+		.reduce((sum, meal) => sum + (meal.caloriesEstimate || 0), 0);
 });
 
-let toggleReminderDialogTitle = $derived(
+const toggleReminderDialogTitle = $derived(
 	reminderToToggle?.enabled ? 'Enable Reminder' : 'Disable Reminder'
 );
-let toggleReminderDialogMessage = $derived(
+const toggleReminderDialogMessage = $derived(
 	reminderToToggle?.enabled
 		? 'Are you sure you want to enable this reminder?'
 		: 'Are you sure you want to disable this reminder?'
 );
-let toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enable' : 'Disable');
+const toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enable' : 'Disable');
 </script>
 
 {#if navigating.to?.url.pathname === '/fitness'}
 	<PageSkeleton color="green" />
 {:else}
 	<PageShell>
+		<!-- Page header -->
 		<div class="mb-8">
-			<h1 class="font-display text-3xl font-bold">Fitness & Nutrition</h1>
+			<h1
+				class="font-display bg-linear-to-r from-green-500 to-emerald-600 bg-clip-text text-3xl font-bold text-transparent"
+			>
+				Fitness & Nutrition
+			</h1>
 			<p class="mt-2 text-muted-foreground">
 				Track your weight, workouts, and meals to achieve your fitness goals
 			</p>
@@ -246,260 +153,104 @@ let toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enabl
 			>
 				<Tabs.Trigger
 					value="workouts"
-					class="font-display flex items-center gap-2 border-b-2 border-transparent data-[state=active]:border-green-500"
+					class="font-display flex items-center gap-2 data-[state=active]:bg-green-500/15 data-[state=active]:text-green-700 dark:data-[state=active]:text-green-400"
 				>
 					<DumbbellIcon class="h-4 w-4" />
 					<span>Workouts</span>
 				</Tabs.Trigger>
-
 				<Tabs.Trigger
 					value="weight"
-					class="font-display flex items-center gap-2 border-b-2 border-transparent data-[state=active]:border-green-500"
+					class="font-display flex items-center gap-2 data-[state=active]:bg-green-500/15 data-[state=active]:text-green-700 dark:data-[state=active]:text-green-400"
 				>
 					<ScaleIcon class="h-4 w-4" />
 					<span>Weight</span>
 				</Tabs.Trigger>
 				<Tabs.Trigger
 					value="meals"
-					class="font-display flex items-center gap-2 border-b-2 border-transparent data-[state=active]:border-green-500"
+					class="font-display flex items-center gap-2 data-[state=active]:bg-green-500/15 data-[state=active]:text-green-700 dark:data-[state=active]:text-green-400"
 				>
 					<UtensilsCrossedIcon class="h-4 w-4" />
 					<span>Meals</span>
 				</Tabs.Trigger>
 				<Tabs.Trigger
 					value="reminders"
-					class="font-display flex items-center gap-2 border-b-2 border-transparent data-[state=active]:border-green-500"
+					class="font-display flex items-center gap-2 data-[state=active]:bg-green-500/15 data-[state=active]:text-green-700 dark:data-[state=active]:text-green-400"
 				>
 					<BellRingIcon class="h-4 w-4" />
 					<span>Reminders</span>
 				</Tabs.Trigger>
 			</Tabs.List>
 
+			<!-- ─── WORKOUTS TAB ─────────────────────────────────────── -->
 			<Tabs.Content value="workouts" class="mt-6 w-full space-y-6">
-				<!-- Log Workout Form -->
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Log Workout</Card.Title>
-						<Card.Description>Record your workout session</Card.Description>
-					</Card.Header>
-					<Card.Content>
-						<form method="POST" action="?/logWorkout" use:workoutEnhance>
-							<div class="grid gap-4">
-								<div class="grid grid-cols-2 gap-4">
-									<div class="grid gap-2">
-										<Label for="workout-date">Date</Label>
-										<Input
-											id="workout-date"
-											name="date"
-											type="date"
-											bind:value={$workoutForm.date}
-											required
-										/>
-										{#if $workoutErrors.date}
-											<p class="text-sm text-destructive">{$workoutErrors.date}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="workout-time">Time (optional)</Label>
-										<Input
-											id="workout-time"
-											name="time"
-											type="time"
-											bind:value={$workoutForm.time}
-										/>
-										{#if $workoutErrors.time}
-											<p class="text-sm text-destructive">{$workoutErrors.time}</p>
-										{/if}
-									</div>
-								</div>
+				<div class="flex items-center justify-between">
+					<div>
+						<h2 class="font-display text-xl font-bold">Workouts</h2>
+						<p class="text-sm text-muted-foreground">Your training history</p>
+					</div>
+					<LogWorkoutDialog formData={data.workoutForm} />
+				</div>
 
-								<div class="grid gap-2">
-									<Label for="workout-type">Workout Type</Label>
-									<Select.Root type="single" name="type" bind:value={$workoutForm.type}>
-										<Select.Trigger id="workout-type">
-											{$workoutForm.type || 'Select workout type'}
-										</Select.Trigger>
-										<Select.Content>
-											<Select.Item value="strength" label="Strength">Strength</Select.Item>
-											<Select.Item value="cardio" label="Cardio">Cardio</Select.Item>
-											<Select.Item value="yoga" label="Yoga">Yoga</Select.Item>
-											<Select.Item value="other" label="Other">Other</Select.Item>
-										</Select.Content>
-									</Select.Root>
-									{#if $workoutErrors.type}
-										<p class="text-sm text-destructive">{$workoutErrors.type}</p>
-									{/if}
-								</div>
+				<WorkoutStatsBar workouts={data.workouts} />
 
-								<div class="grid gap-2">
-									<Label for="workout-duration">Duration (minutes)</Label>
-									<Input
-										id="workout-duration"
-										name="durationMinutes"
-										type="number"
-										bind:value={$workoutForm.durationMinutes}
-										placeholder="60"
-									/>
-									{#if $workoutErrors.durationMinutes}
-										<p class="text-sm text-destructive">{$workoutErrors.durationMinutes}</p>
-									{/if}
-								</div>
+				<WorkoutFrequencyChart workouts={data.workouts} />
 
-								{#if $workoutForm.type === 'strength'}
-									<ExerciseInput bind:exercises={workoutExercises} />
-									<Input type="hidden" name="exercises" value={JSON.stringify(workoutExercises)} />
-									{#if $workoutErrors.exercises}
-										<p class="text-sm text-destructive">{$workoutErrors.exercises}</p>
-									{/if}
-								{/if}
-
-								<div class="grid gap-2">
-									<Label for="workout-notes">Notes (optional)</Label>
-									<LongTextInput
-										id="workout-notes"
-										name="notes"
-										bind:value={$workoutForm.notes}
-										rows={3}
-										placeholder="How did the workout feel?"
-									/>
-									{#if $workoutErrors.notes}
-										<p class="text-sm text-destructive">{$workoutErrors.notes}</p>
-									{/if}
-								</div>
-
-								<Button type="submit" class="text-white bg-green-600 hover:bg-green-700">
-									Log Workout
-								</Button>
-							</div>
-						</form>
-					</Card.Content>
-				</Card.Root>
-
-				<!-- Recent Workouts -->
 				{#if data.workouts.length > 0}
 					<Card.Root>
 						<Card.Header> <Card.Title>Recent Workouts</Card.Title> </Card.Header>
-						<Card.Content>
-							<div class="space-y-3">
-								{#each data.workouts.slice(0, 10) as workout (workout.id)}
-									<div class="rounded-lg border p-4">
-										<div class="flex items-start justify-between">
-											<div class="space-y-1">
-												<div class="flex items-center gap-2">
-													<span
-														class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize"
-														class:bg-orange-100={workout.type === 'strength'}
-														class:text-orange-800={workout.type === 'strength'}
-														class:bg-blue-100={workout.type === 'cardio'}
-														class:text-blue-800={workout.type === 'cardio'}
-														class:bg-purple-100={workout.type === 'yoga'}
-														class:text-purple-800={workout.type === 'yoga'}
-														class:bg-gray-100={workout.type === 'other'}
-														class:text-gray-800={workout.type === 'other'}
-													>
-														{workout.type}
-													</span>
-													{#if workout.durationMinutes}
-														<span class="text-sm text-muted-foreground">
-															{workout.durationMinutes}
-															min
-														</span>
-													{/if}
-												</div>
-												<p class="text-sm text-muted-foreground">
-													{formatDateMedium(workout.date)}
-													{#if workout.time}
-														@ {formatTime12Hour(workout.time)}
-													{/if}
-												</p>
-												{#if workout.notes}
-													<p class="mt-2 text-sm">{workout.notes}</p>
-												{/if}
-												{#if workout.exercises && workout.exercises.length > 0}
-													<div class="mt-3 space-y-2">
-														<p class="text-sm font-medium">Exercises:</p>
-														{#each workout.exercises as exercise (exercise.exerciseName)}
-															<div class="ml-4 text-sm text-muted-foreground">
-																• {exercise.exerciseName}
-																{#if exercise.sets || exercise.reps || exercise.weightLbs}
-																	<span class="ml-2">
-																		{#if exercise.sets}
-																			{exercise.sets}
-																			sets
-																		{/if}
-																		{#if exercise.reps}
-																			× {exercise.reps} reps
-																		{/if}
-																		{#if exercise.weightLbs}
-																			@ {exercise.weightLbs} lbs
-																		{/if}
-																	</span>
-																{/if}
-															</div>
-														{/each}
-													</div>
-												{/if}
-											</div>
-											<div class="mt-3 flex items-center gap-2">
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																variant="outline"
-																size="icon"
-																href="/fitness/workouts/{workout.id}/edit"
-																aria-label="Edit workout"
-															>
-																<Edit class="h-4 w-4" />
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Edit</Tooltip.Content>
-												</Tooltip.Root>
-
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																type="button"
-																variant="destructive"
-																size="icon"
-																onclick={() => {
-																	workoutToDelete = workout.id;
-																	showDeleteWorkoutDialog = true;
-																}}
-																aria-label="Delete workout"
-															>
-																<Trash2 class="h-4 w-4" />
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Delete</Tooltip.Content>
-												</Tooltip.Root>
-											</div>
-										</div>
-									</div>
-								{/each}
-							</div>
-							{#if workoutToDelete}
-								<ConfirmDialog
-									bind:open={showDeleteWorkoutDialog}
-									title="Delete Workout"
-									message="Are you sure you want to delete this workout? This action cannot be undone."
-									confirmButtonText="Delete"
-									actionUrl="/fitness/workouts/{workoutToDelete}/edit?/delete"
-									id={workoutToDelete}
+						<Card.Content class="max-h-96 overflow-y-auto space-y-2 pr-1">
+							{#each data.workouts.slice(0, 10) as workout (workout.id)}
+								<WorkoutEntryCard
+									{workout}
+									onEdit={(w) => {
+										workoutToEdit = w;
+									}}
+									onDelete={(id) => {
+										workoutToDelete = id;
+										showDeleteWorkoutDialog = true;
+									}}
 								/>
-							{/if}
+							{/each}
 						</Card.Content>
 					</Card.Root>
 				{/if}
+
+				{#if workoutToEdit}
+					<LogWorkoutDialog
+						formData={data.workoutForm}
+						editEntry={workoutToEdit}
+						onClose={() => {
+							workoutToEdit = null;
+						}}
+					/>
+				{/if}
+
+				{#if workoutToDelete}
+					<ConfirmDialog
+						bind:open={showDeleteWorkoutDialog}
+						title="Delete Workout"
+						message="Are you sure you want to delete this workout? This action cannot be undone."
+						confirmButtonText="Delete"
+						actionUrl="?/deleteWorkout"
+						id={workoutToDelete}
+					/>
+				{/if}
 			</Tabs.Content>
 
+			<!-- ─── WEIGHT TAB ────────────────────────────────────────── -->
 			<Tabs.Content value="weight" class="mt-6 w-full space-y-6">
-				<!-- Stats Cards -->
+				<div class="flex items-center justify-between">
+					<div>
+						<h2 class="font-display text-xl font-bold">Weight</h2>
+						<p class="text-sm text-muted-foreground">Track your progress toward your goal</p>
+					</div>
+					<div class="flex items-center gap-2">
+						<SetGoalWeightDialog formData={data.goalForm} />
+						<LogWeightDialog formData={data.weightForm} />
+					</div>
+				</div>
+
+				<!-- Stats row -->
 				<div class="grid gap-4 md:grid-cols-4">
 					<Card.Root>
 						<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -564,93 +315,9 @@ let toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enabl
 					</Card.Root>
 				</div>
 
-				<div class="grid gap-6 lg:grid-cols-2">
-					<!-- Log Weight Form -->
-					<Card.Root>
-						<Card.Header>
-							<Card.Title>Log Weight</Card.Title>
-							<Card.Description>Record your current weight</Card.Description>
-						</Card.Header>
-						<Card.Content>
-							<form method="POST" action="?/logWeight" use:weightEnhance>
-								<div class="grid gap-4">
-									<div class="grid gap-2">
-										<Label for="weight-date">Date</Label>
-										<Input
-											id="weight-date"
-											name="date"
-											type="date"
-											bind:value={$weightForm.date}
-											required
-										/>
-										{#if $weightErrors.date}
-											<p class="text-sm text-destructive">{$weightErrors.date}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="weight-time">Time (optional)</Label>
-										<Input id="weight-time" name="time" type="time" bind:value={$weightForm.time} />
-										{#if $weightErrors.time}
-											<p class="text-sm text-destructive">{$weightErrors.time}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="weight-lbs">Weight (lbs)</Label>
-										<Input
-											id="weight-lbs"
-											name="weightLbs"
-											type="number"
-											step="0.1"
-											bind:value={$weightForm.weightLbs}
-											required
-										/>
-										{#if $weightErrors.weightLbs}
-											<p class="text-sm text-destructive">{$weightErrors.weightLbs}</p>
-										{/if}
-										<Button type="submit" class="w-full text-white bg-green-600 hover:bg-green-700"
-											>Log Weight</Button
-										>
-									</div>
-								</div>
-							</form>
-						</Card.Content>
-					</Card.Root>
-
-					<!-- Set Goal Weight Form -->
-					<Card.Root>
-						<Card.Header>
-							<Card.Title>Set Goal Weight</Card.Title>
-							<Card.Description>Define your target weight goal</Card.Description>
-						</Card.Header>
-						<Card.Content>
-							<form method="POST" action="?/setGoal" use:goalEnhance>
-								<div class="grid gap-4">
-									<div class="grid gap-2">
-										<Label for="goal-weight">Target Weight (lbs)</Label>
-										<Input
-											id="goal-weight"
-											name="targetWeightLbs"
-											type="number"
-											step="0.1"
-											bind:value={$goalForm.targetWeightLbs}
-											required
-										/>
-										{#if $goalErrors.targetWeightLbs}
-											<p class="text-sm text-destructive">{$goalErrors.targetWeightLbs}</p>
-										{/if}
-									</div>
-									<Button type="submit" class="w-full text-white bg-green-600 hover:bg-green-700"
-										>Set Goal</Button
-									>
-								</div>
-							</form>
-						</Card.Content>
-					</Card.Root>
-				</div>
-
-				<!-- Weight Chart -->
+				<!-- Weight chart -->
 				{#if data.weightEntries.length === 0}
-					<div class="flex h-75 items-center justify-center rounded-lg border border-dashed">
+					<div class="flex h-48 items-center justify-center rounded-lg border border-dashed">
 						<p class="text-sm text-muted-foreground">
 							No weight data yet. Start logging to see your progress!
 						</p>
@@ -664,536 +331,137 @@ let toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enabl
 					/>
 				{/if}
 
-				<!-- Recent Entries -->
+				<!-- Recent weight entries -->
 				{#if data.weightEntries.length > 0}
 					<Card.Root>
 						<Card.Header> <Card.Title>Recent Entries</Card.Title> </Card.Header>
-						<Card.Content>
-							<div class="space-y-2">
-								{#each data.weightEntries.slice(0, 10) as entry (entry.id)}
-									<div class="flex items-center justify-between rounded-lg border p-3">
-										<div>
-											<p class="font-medium">{entry.weightLbs} lbs</p>
-											<p class="text-sm text-muted-foreground">
-												{formatDateShort(entry.date)}
-												{#if entry.time}
-													@ {formatTime12Hour(entry.time)}
-												{/if}
-											</p>
-										</div>
-										<div class="flex items-center gap-2">
-											<Tooltip.Root>
-												<Tooltip.Trigger>
-													{#snippet child({ props })}
-														<Button
-															{...props}
-															variant="outline"
-															size="icon"
-															href="/fitness/weight/{entry.id}/edit"
-															aria-label="Edit weight entry"
-														>
-															<Edit class="h-4 w-4" />
-														</Button>
-													{/snippet}
-												</Tooltip.Trigger>
-												<Tooltip.Content>Edit</Tooltip.Content>
-											</Tooltip.Root>
-
-											<Tooltip.Root>
-												<Tooltip.Trigger>
-													{#snippet child({ props })}
-														<Button
-															{...props}
-															type="button"
-															variant="destructive"
-															size="icon"
-															onclick={() => {
-																weightEntryToDelete = entry.id;
-																showDeleteWeightDialog = true;
-															}}
-															aria-label="Delete weight entry"
-														>
-															<Trash2 class="h-4 w-4" />
-														</Button>
-													{/snippet}
-												</Tooltip.Trigger>
-												<Tooltip.Content>Delete</Tooltip.Content>
-											</Tooltip.Root>
-										</div>
-									</div>
-								{/each}
-							</div>
-							{#if weightEntryToDelete}
-								<ConfirmDialog
-									bind:open={showDeleteWeightDialog}
-									title="Delete Weight Entry"
-									message="Are you sure you want to delete this weight entry? This action cannot be undone."
-									confirmButtonText="Delete"
-									actionUrl="/fitness/weight/{weightEntryToDelete}/edit?/delete"
-									id={weightEntryToDelete}
+						<Card.Content class="max-h-96 overflow-y-auto space-y-2 pr-1">
+							{#each data.weightEntries.slice(0, 10) as entry, i (entry.id)}
+								<WeightEntryCard
+									{entry}
+									previousEntry={data.weightEntries[i + 1] ?? null}
+									onEdit={(e) => {
+										weightToEdit = e;
+									}}
+									onDelete={(id) => {
+										weightEntryToDelete = id;
+										showDeleteWeightDialog = true;
+									}}
 								/>
-							{/if}
+							{/each}
 						</Card.Content>
 					</Card.Root>
 				{/if}
+
+				{#if weightToEdit}
+					<LogWeightDialog
+						formData={data.weightForm}
+						editEntry={weightToEdit}
+						onClose={() => {
+							weightToEdit = null;
+						}}
+					/>
+				{/if}
+
+				{#if weightEntryToDelete}
+					<ConfirmDialog
+						bind:open={showDeleteWeightDialog}
+						title="Delete Weight Entry"
+						message="Are you sure you want to delete this weight entry? This action cannot be undone."
+						confirmButtonText="Delete"
+						actionUrl="?/deleteWeight"
+						id={weightEntryToDelete}
+					/>
+				{/if}
 			</Tabs.Content>
 
+			<!-- ─── MEALS TAB ─────────────────────────────────────────── -->
 			<Tabs.Content value="meals" class="mt-6 w-full space-y-6">
-				<!-- Calorie Progress -->
+				<div class="flex items-center justify-between">
+					<div>
+						<h2 class="font-display text-xl font-bold">Meals</h2>
+						<p class="text-sm text-muted-foreground">Nutrition tracking and calorie goals</p>
+					</div>
+					<div class="flex items-center gap-2">
+						<SetCalorieTargetDialog formData={data.calorieForm} />
+						<LogMealDialog formData={data.mealForm} />
+					</div>
+				</div>
+
 				<CalorieProgress
 					consumed={todayTotalCalories}
 					target={data.calorieTarget?.targetCalories || null}
 				/>
 
-				<div class="grid gap-6 lg:grid-cols-2">
-					<!-- Log Meal Form -->
-					<Card.Root>
-						<Card.Header>
-							<Card.Title>Log Meal</Card.Title>
-							<Card.Description>Record what you ate</Card.Description>
-						</Card.Header>
-						<Card.Content>
-							<form method="POST" action="?/logMeal" use:mealEnhance>
-								<div class="grid gap-4">
-									<div class="grid gap-2">
-										<Label for="meal-date">Date</Label>
-										<Input
-											id="meal-date"
-											name="date"
-											type="date"
-											bind:value={$mealForm.date}
-											required
-										/>
-										{#if $mealErrors.date}
-											<p class="text-sm text-destructive">{$mealErrors.date}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="meal-time">Meal Type</Label>
-										<Select.Root type="single" name="timeOfDay" bind:value={$mealForm.timeOfDay}>
-											<Select.Trigger id="meal-time">
-												{$mealForm.timeOfDay || 'Select meal type'}
-											</Select.Trigger>
-											<Select.Content>
-												<Select.Item value="breakfast" label="Breakfast">Breakfast</Select.Item>
-												<Select.Item value="lunch" label="Lunch">Lunch</Select.Item>
-												<Select.Item value="dinner" label="Dinner">Dinner</Select.Item>
-												<Select.Item value="snack" label="Snack">Snack</Select.Item>
-											</Select.Content>
-										</Select.Root>
-										{#if $mealErrors.timeOfDay}
-											<p class="text-sm text-destructive">{$mealErrors.timeOfDay}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="meal-description">Description</Label>
-										<LongTextInput
-											id="meal-description"
-											name="description"
-											bind:value={$mealForm.description}
-											rows={3}
-											placeholder="e.g., Chicken salad with olive oil dressing"
-											required
-										/>
-										{#if $mealErrors.description}
-											<p class="text-sm text-destructive">{$mealErrors.description}</p>
-										{/if}
-									</div>
-									<div class="grid gap-2">
-										<Label for="meal-calories">Calories (estimate)</Label>
-										<Input
-											id="meal-calories"
-											name="caloriesEstimate"
-											type="number"
-											bind:value={$mealForm.caloriesEstimate}
-											placeholder="500"
-										/>
-										{#if $mealErrors.caloriesEstimate}
-											<p class="text-sm text-destructive">{$mealErrors.caloriesEstimate}</p>
-										{/if}
-									</div>
-									<Button type="submit" class="w-full text-white bg-green-600 hover:bg-green-700"
-										>Log Meal</Button
-									>
-								</div>
-							</form>
-						</Card.Content>
-					</Card.Root>
-
-					<!-- Set Calorie Target Form -->
-					<Card.Root>
-						<Card.Header>
-							<Card.Title>Set Calorie Target</Card.Title>
-							<Card.Description>Define your daily calorie goal</Card.Description>
-						</Card.Header>
-						<Card.Content>
-							<form method="POST" action="?/setCalorieTarget" use:calorieEnhance>
-								<div class="grid gap-4">
-									<div class="grid gap-2">
-										<Label for="calorie-target">Daily Target (calories)</Label>
-										<Input
-											id="calorie-target"
-											name="targetCalories"
-											type="number"
-											bind:value={$calorieForm.targetCalories}
-											placeholder="2000"
-											class={$calorieErrors.targetCalories ? 'border-destructive' : ''}
-											required
-										/>
-										{#if $calorieErrors.targetCalories}
-											<p class="text-sm text-destructive">{$calorieErrors.targetCalories}</p>
-										{/if}
-									</div>
-									{#if $calorieMessage}
-										<div class="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-											{$calorieMessage}
-										</div>
-									{/if}
-									<Button type="submit" class="w-full text-white bg-green-600 hover:bg-green-700"
-										>Set Target</Button
-									>
-								</div>
-							</form>
-						</Card.Content>
-					</Card.Root>
-				</div>
-
-				<!-- Recent Meals -->
 				{#if data.meals.length > 0}
 					<Card.Root>
 						<Card.Header> <Card.Title>Recent Meals</Card.Title> </Card.Header>
-						<Card.Content>
-							<div class="space-y-3">
-								{#each data.meals.slice(0, 15) as meal (meal.id)}
-									<div class="rounded-lg border p-4">
-										<div class="flex items-start justify-between">
-											<div class="space-y-1">
-												<div class="flex items-center gap-2">
-													<span
-														class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize"
-														class:bg-yellow-100={meal.timeOfDay === 'breakfast'}
-														class:text-yellow-800={meal.timeOfDay === 'breakfast'}
-														class:bg-green-100={meal.timeOfDay === 'lunch'}
-														class:text-green-800={meal.timeOfDay === 'lunch'}
-														class:bg-blue-100={meal.timeOfDay === 'dinner'}
-														class:text-blue-800={meal.timeOfDay === 'dinner'}
-														class:bg-purple-100={meal.timeOfDay === 'snack'}
-														class:text-purple-800={meal.timeOfDay === 'snack'}
-													>
-														{meal.timeOfDay}
-													</span>
-													{#if meal.caloriesEstimate}
-														<span class="text-sm font-medium">{meal.caloriesEstimate} cal</span>
-													{/if}
-												</div>
-												<p class="text-sm text-muted-foreground">{formatDateShort(meal.date)}</p>
-												<p class="mt-2 text-sm">{meal.description}</p>
-											</div>
-											<div class="mt-3 flex items-center gap-2">
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																variant="outline"
-																size="icon"
-																href="/fitness/meals/{meal.id}/edit"
-																aria-label="Edit meal"
-															>
-																<Edit class="h-4 w-4" />
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Edit</Tooltip.Content>
-												</Tooltip.Root>
-
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																type="button"
-																variant="destructive"
-																size="icon"
-																onclick={() => {
-																	mealToDelete = meal.id;
-																	showDeleteMealDialog = true;
-																}}
-																aria-label="Delete meal"
-															>
-																<Trash2 class="h-4 w-4" />
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Delete</Tooltip.Content>
-												</Tooltip.Root>
-											</div>
-										</div>
-									</div>
-								{/each}
-							</div>
-							{#if mealToDelete}
-								<ConfirmDialog
-									bind:open={showDeleteMealDialog}
-									title="Delete Meal"
-									message="Are you sure you want to delete this meal entry? This action cannot be undone."
-									confirmButtonText="Delete"
-									actionUrl="/fitness/meals/{mealToDelete}/edit?/delete"
-									id={mealToDelete}
+						<Card.Content class="max-h-96 overflow-y-auto space-y-2 pr-1">
+							{#each data.meals.slice(0, 15) as meal (meal.id)}
+								<MealEntryCard
+									{meal}
+									onEdit={(m) => {
+										mealToEdit = m;
+									}}
+									onDelete={(id) => {
+										mealToDelete = id;
+										showDeleteMealDialog = true;
+									}}
 								/>
-							{/if}
+							{/each}
 						</Card.Content>
 					</Card.Root>
 				{/if}
+
+				{#if mealToEdit}
+					<LogMealDialog
+						formData={data.mealForm}
+						editEntry={mealToEdit}
+						onClose={() => {
+							mealToEdit = null;
+						}}
+					/>
+				{/if}
+
+				{#if mealToDelete}
+					<ConfirmDialog
+						bind:open={showDeleteMealDialog}
+						title="Delete Meal"
+						message="Are you sure you want to delete this meal entry? This action cannot be undone."
+						confirmButtonText="Delete"
+						actionUrl="?/deleteMeal"
+						id={mealToDelete}
+					/>
+				{/if}
 			</Tabs.Content>
 
+			<!-- ─── REMINDERS TAB ─────────────────────────────────────── -->
 			<Tabs.Content value="reminders" class="mt-6 w-full space-y-6">
-				<!-- Create Reminder Form -->
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>Schedule Workout Reminder</Card.Title>
-						<Card.Description>
-							Get email reminders to stay consistent with your workout routine
-						</Card.Description>
-					</Card.Header>
-					<Card.Content>
-						<form method="POST" action="?/createReminder" use:reminderEnhance>
-							<div class="grid gap-4 md:grid-cols-2">
-								<div class="space-y-2">
-									<Label for="workoutType">Workout Type</Label>
-									<Select.Root
-										type="single"
-										name="workoutType"
-										bind:value={$reminderForm.workoutType}
-									>
-										<Select.Trigger id="workoutType">
-											{$reminderForm.workoutType || 'Select workout type'}
-										</Select.Trigger>
-										<Select.Content>
-											<Select.Item value="strength" label="Strength">Strength</Select.Item>
-											<Select.Item value="cardio" label="Cardio">Cardio</Select.Item>
-											<Select.Item value="yoga" label="Yoga">Yoga</Select.Item>
-											<Select.Item value="other" label="Other">Other</Select.Item>
-										</Select.Content>
-									</Select.Root>
-									{#if $reminderErrors.workoutType}
-										<p class="text-sm text-destructive">{$reminderErrors.workoutType}</p>
-									{/if}
-								</div>
+				<div class="flex items-center justify-between">
+					<div>
+						<h2 class="font-display text-xl font-bold">Reminders</h2>
+						<p class="text-sm text-muted-foreground">Email reminders to keep you consistent</p>
+					</div>
+					<CreateReminderDialog formData={data.reminderForm} />
+				</div>
 
-								<div class="space-y-2">
-									<Label for="reminderTime">Time</Label>
-									<Input
-										id="reminderTime"
-										name="time"
-										type="time"
-										bind:value={$reminderForm.time}
-										placeholder="HH:MM"
-										required
-									/>
-									{#if $reminderErrors.time}
-										<p class="text-sm text-destructive">{$reminderErrors.time}</p>
-									{/if}
-								</div>
-
-								<div class="space-y-2">
-									<Label for="cadence">Frequency</Label>
-									<Select.Root type="single" name="cadence" bind:value={$reminderForm.cadence}>
-										<Select.Trigger id="cadence">
-											{$reminderForm.cadence || 'Select frequency'}
-										</Select.Trigger>
-										<Select.Content>
-											<Select.Item value="daily" label="Daily">Daily</Select.Item>
-											<Select.Item value="weekly" label="Weekly">Weekly</Select.Item>
-										</Select.Content>
-									</Select.Root>
-									{#if $reminderErrors.cadence}
-										<p class="text-sm text-destructive">{$reminderErrors.cadence}</p>
-									{/if}
-								</div>
-
-								{#if $reminderForm.cadence === 'weekly'}
-									<div class="space-y-2">
-										<Label>Days of Week</Label>
-										<Input
-											id="daysOfWeek"
-											name="daysOfWeek"
-											type="text"
-											bind:value={$reminderForm.daysOfWeek}
-											hidden
-										/>
-										<div class="flex flex-wrap gap-2">
-											{#each daysOfWeek as day (day.id)}
-												{@const selectedDays = $reminderForm.daysOfWeek
-													? JSON.parse($reminderForm.daysOfWeek)
-													: []}
-												<Button
-													type="button"
-													variant={selectedDays.includes(day.id) ? 'default' : 'outline'}
-													size="sm"
-													onclick={() => {
-														const days = $reminderForm.daysOfWeek
-															? JSON.parse($reminderForm.daysOfWeek)
-															: [];
-														if (days.includes(day.id)) {
-															$reminderForm.daysOfWeek = JSON.stringify(
-																days.filter((d: number) => d !== day.id)
-															);
-														} else {
-															$reminderForm.daysOfWeek = JSON.stringify([...days, day.id].sort());
-														}
-													}}
-												>
-													{day.shortName}
-												</Button>
-											{/each}
-										</div>
-										{#if $reminderErrors.daysOfWeek}
-											<p class="text-sm text-destructive">{$reminderErrors.daysOfWeek}</p>
-										{/if}
-									</div>
-								{/if}
-							</div>
-
-							<div class="mt-4">
-								<Button type="submit" class="text-white bg-green-600 hover:bg-green-700"
-									>Create Reminder</Button
-								>
-							</div>
-						</form>
-					</Card.Content>
-				</Card.Root>
-
-				<!-- Active Reminders List -->
 				{#if data.reminders.length > 0}
 					<Card.Root>
 						<Card.Header> <Card.Title>Active Reminders</Card.Title> </Card.Header>
-						<Card.Content>
-							<div class="space-y-3">
-								{#each data.reminders as reminder (reminder.id)}
-									<div class="rounded-lg border p-4">
-										<div class="flex items-start justify-between">
-											<div class="flex-1 space-y-1">
-												<div class="flex items-center gap-2">
-													<span
-														class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize"
-														class:bg-purple-100={reminder.workoutType === 'strength'}
-														class:text-purple-800={reminder.workoutType === 'strength'}
-														class:bg-blue-100={reminder.workoutType === 'cardio'}
-														class:text-blue-800={reminder.workoutType === 'cardio'}
-														class:bg-green-100={reminder.workoutType === 'yoga'}
-														class:text-green-800={reminder.workoutType === 'yoga'}
-														class:bg-gray-100={reminder.workoutType === 'other'}
-														class:text-gray-800={reminder.workoutType === 'other'}
-													>
-														{reminder.workoutType}
-													</span>
-													<span class="text-sm font-medium">{formatTime12Hour(reminder.time)}</span>
-													{#if !reminder.enabled}
-														<span class="text-xs text-muted-foreground">(Disabled)</span>
-													{/if}
-												</div>
-												<p class="text-sm text-muted-foreground">
-													{reminder.cadence === 'daily'
-														? 'Every day'
-														: `Weekly on ${
-																reminder.daysOfWeek
-																	? JSON.parse(reminder.daysOfWeek)
-																			.map(
-																				(d: string) => daysOfWeek[d as unknown as number].shortName
-																			)
-																			.join(', ')
-																	: 'Not configured'
-															}`}
-												</p>
-											</div>
-											<div class="flex gap-2">
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																type="button"
-																variant="outline"
-																size="icon"
-																onclick={() => {
-																	reminderToToggle = {
-																		id: reminder.id,
-																		workoutType: reminder.workoutType,
-																		cadence: reminder.cadence,
-																		time: reminder.time,
-																		daysOfWeek: reminder.daysOfWeek || '',
-																		enabled: !reminder.enabled
-																	};
-																	showToggleReminderDialog = true;
-																}}
-																aria-label={reminder.enabled ? 'Disable reminder' : 'Enable reminder'}
-																title={reminder.enabled ? 'Disable' : 'Enable'}
-															>
-																{#if reminder.enabled}
-																	<BellOffIcon class="h-4 w-4" />
-																{:else}
-																	<BellIcon class="h-4 w-4" />
-																{/if}
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Disable</Tooltip.Content>
-												</Tooltip.Root>
-
-												<Tooltip.Root>
-													<Tooltip.Trigger>
-														{#snippet child({ props })}
-															<Button
-																{...props}
-																type="button"
-																variant="destructive"
-																size="icon"
-																onclick={() => {
-																	reminderToDelete = reminder.id;
-																	showDeleteReminderDialog = true;
-																}}
-																aria-label="Delete reminder"
-															>
-																<Trash2 class="h-4 w-4" />
-															</Button>
-														{/snippet}
-													</Tooltip.Trigger>
-													<Tooltip.Content>Delete</Tooltip.Content>
-												</Tooltip.Root>
-											</div>
-										</div>
-									</div>
-								{/each}
-							</div>
-							{#if reminderToToggle}
-								<ConfirmDialog
-									bind:open={showToggleReminderDialog}
-									title={toggleReminderDialogTitle || 'Update Reminder'}
-									message={toggleReminderDialogMessage ||
-										'Are you sure you want to update this reminder?'}
-									confirmButtonText={toggleReminderDialogButtonText || 'Confirm'}
-									actionUrl="?/updateReminder"
-									id={reminderToToggle.id}
-									hiddenFields={{
-										workoutType: reminderToToggle.workoutType,
-										cadence: reminderToToggle.cadence,
-										time: reminderToToggle.time,
-										daysOfWeek: reminderToToggle.daysOfWeek,
-										enabled: reminderToToggle.enabled
+						<Card.Content class="space-y-2">
+							{#each data.reminders as reminder (reminder.id)}
+								<ReminderCard
+									{reminder}
+									onToggle={(r) => {
+										reminderToToggle = r;
+										showToggleReminderDialog = true;
+									}}
+									onDelete={(id) => {
+										reminderToDelete = id;
+										showDeleteReminderDialog = true;
 									}}
 								/>
-							{/if}
-							{#if reminderToDelete}
-								<ConfirmDialog
-									bind:open={showDeleteReminderDialog}
-									title="Delete Reminder"
-									message="Are you sure you want to delete this reminder? This action cannot be undone."
-									confirmButtonText="Delete"
-									actionUrl="?/deleteReminder"
-									id={reminderToDelete}
-								/>
-							{/if}
+							{/each}
 						</Card.Content>
 					</Card.Root>
 				{:else}
@@ -1203,6 +471,35 @@ let toggleReminderDialogButtonText = $derived(reminderToToggle?.enabled ? 'Enabl
 							<p class="mt-1 text-sm">Create your first reminder above to get started!</p>
 						</Card.Content>
 					</Card.Root>
+				{/if}
+
+				{#if reminderToToggle}
+					<ConfirmDialog
+						bind:open={showToggleReminderDialog}
+						title={toggleReminderDialogTitle || 'Update Reminder'}
+						message={toggleReminderDialogMessage || 'Are you sure you want to update this reminder?'}
+						confirmButtonText={toggleReminderDialogButtonText || 'Confirm'}
+						actionUrl="?/updateReminder"
+						id={reminderToToggle.id}
+						hiddenFields={{
+							workoutType: reminderToToggle.workoutType,
+							cadence: reminderToToggle.cadence,
+							time: reminderToToggle.time,
+							daysOfWeek: reminderToToggle.daysOfWeek ?? '',
+							enabled: reminderToToggle.enabled
+						}}
+					/>
+				{/if}
+
+				{#if reminderToDelete}
+					<ConfirmDialog
+						bind:open={showDeleteReminderDialog}
+						title="Delete Reminder"
+						message="Are you sure you want to delete this reminder? This action cannot be undone."
+						confirmButtonText="Delete"
+						actionUrl="?/deleteReminder"
+						id={reminderToDelete}
+					/>
 				{/if}
 			</Tabs.Content>
 		</Tabs.Root>


### PR DESCRIPTION
Server [+page.server.ts]:
- Added 6 new actions: updateWeight, deleteWeight, updateWorkout, deleteWorkout, updateMeal, deleteMeal — all with ownership checks, mirroring the logic from the separate edit routes

Dialogs (now dual-purpose create/edit):
- [LogWeightDialog.svelte] — accepts optional editEntry prop; when set, opens automatically, populates the form, submits to ?/updateWeight, and shows "Edit Weight Entry" title
- [LogWorkoutDialog.svelte] — same pattern, also pre-populates exercises for strength workouts
- [LogMealDialog.svelte] — same pattern with meal type casting

Entry Cards — edit buttons changed from href navigation to onEdit callbacks:
- [WorkoutEntryCard.svelte]
- [WeightEntryCard.svelte]
- [MealEntryCard.svelte]

Page [+page.svelte]:
- Added weightToEdit, workoutToEdit, mealToEdit state
- Renders edit dialogs conditionally when edit state is set
- Delete ConfirmDialogs now use ?/deleteWorkout, ?/deleteWeight, ?/deleteMeal instead of navigating to edit routes
- Removed stale notice handlers for edit-route redirects