### PR TITLE
fix: improve error handling and user feedback in task creation process

### DIFF
--- a/src/lib/components/journal/JournalEntryForm.svelte
+++ b/src/lib/components/journal/JournalEntryForm.svelte
@@ -35,7 +35,6 @@ interface Props {
 let { data, mode }: Props = $props();
 
 const isNewMode = $derived(mode === 'new');
-const isEditMode = $derived(mode === 'edit');
 const formAction = $derived(mode === 'edit' ? '?/update' : undefined);
 const pageTitle = $derived(mode === 'edit' ? 'Edit Journal Entry' : 'New Journal Entry');
 const starterPrompt =

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -90,7 +90,15 @@ class Logger {
 		} else if (typeof error === 'string') {
 			errorPayload.error = error;
 		} else {
-			errorPayload.error = 'Non-Error thrown (details suppressed)';
+			try {
+				errorPayload.error = JSON.parse(
+					JSON.stringify(error, (_key, val) =>
+						val instanceof Error ? { name: val.name, message: val.message } : val
+					)
+				);
+			} catch {
+				errorPayload.error = String(error);
+			}
 		}
 
 		const errorMeta = {

--- a/src/routes/(app)/journal/new/+page.server.ts
+++ b/src/routes/(app)/journal/new/+page.server.ts
@@ -27,7 +27,6 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(journalEntrySchema));
 
 		if (!form.valid) {
-			logger.warn('Invalid journal entry form data', { errors: form.errors });
 			return fail(400, { form });
 		}
 
@@ -57,7 +56,7 @@ export const actions: Actions = {
 
 			logger.info('Journal entry created', { entryId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to create journal entry', { error });
+			logger.error('Failed to create journal entry', { error, userId: user.id });
 			return message(
 				form,
 				{

--- a/src/routes/(app)/tasks/new/+page.server.ts
+++ b/src/routes/(app)/tasks/new/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { and, eq, sql } from 'drizzle-orm';
-import { superValidate } from 'sveltekit-superforms';
+import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import { createTaskSchema, type TaskState, TaskStateEnum } from '$lib/schemas/task';
@@ -39,25 +39,27 @@ async function createTaskWithTaskNumber(
 
 	for (let attempt = 1; attempt <= MAX_TASK_NUMBER_ATTEMPTS; attempt += 1) {
 		try {
-			return await db.transaction(async (tx) => {
-				const [taskNumberRow] = await tx
+			return db.transaction((tx) => {
+				const [taskNumberRow] = tx
 					.select({
 						nextTaskNumber: sql<number>`coalesce(max(${tasks.taskNumber}), 0) + 1`
 					})
-					.from(tasks);
+					.from(tasks)
+					.all();
 
-				const [sortOrderRow] = await tx
+				const [sortOrderRow] = tx
 					.select({
 						maxSortOrder: sql<number>`coalesce(max(${tasks.sortOrder}), -1)`
 					})
 					.from(tasks)
-					.where(and(eq(tasks.userId, userId), eq(tasks.state, input.state)));
+					.where(and(eq(tasks.userId, userId), eq(tasks.state, input.state)))
+					.all();
 
 				const timestamp = new Date().toISOString();
 				const nextTaskNumber = taskNumberRow?.nextTaskNumber ?? 1;
 				const nextSortOrder = (sortOrderRow?.maxSortOrder ?? -1) + 1;
 
-				const [newTask] = await tx
+				const [newTask] = tx
 					.insert(tasks)
 					.values({
 						userId,
@@ -72,7 +74,8 @@ async function createTaskWithTaskNumber(
 						createdAt: timestamp,
 						updatedAt: timestamp
 					})
-					.returning();
+					.returning()
+					.all();
 
 				return newTask;
 			});
@@ -97,9 +100,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		zod4(createTaskSchema)
 	);
 
-	return {
-		form
-	};
+	return { form };
 };
 
 export const actions: Actions = {
@@ -129,7 +130,14 @@ export const actions: Actions = {
 			});
 		} catch (error) {
 			logger.error('Failed to create task', { error, userId: user.id });
-			return fail(500, { form, error: 'Failed to create task' });
+			return message(
+				form,
+				{
+					type: 'error',
+					text: 'An error occurred while creating the task. Please try again.'
+				},
+				{ status: 500 }
+			);
 		}
 
 		throw redirect(303, '/tasks');

--- a/src/routes/(app)/tasks/new/+page.svelte
+++ b/src/routes/(app)/tasks/new/+page.svelte
@@ -2,6 +2,7 @@
 import { ArrowLeft } from '@lucide/svelte';
 import { toast } from 'svelte-sonner';
 import { superForm } from 'sveltekit-superforms';
+import { goto } from '$app/navigation';
 
 import PageFormShell from '$lib/components/shared/PageFormShell.svelte';
 import { taskPriorityOptions, taskStateOptions } from '$lib/components/tasks/task-ui';
@@ -17,12 +18,21 @@ import type { PageData } from './$types';
 let { data }: { data: PageData } = $props();
 
 // svelte-ignore state_referenced_locally
-const { form, errors, enhance, message } = superForm(data.form, {
-	dataType: 'form',
-	onUpdate: ({ form }) => {
-		if (form.valid) {
-			toast.success('Task created successfully!');
-		}
+const { form, errors, enhance, message, submitting } = superForm(data.form, {
+	// dataType: 'form',
+	// onResult: async ({ result, cancel }) => {
+	// 	if (result.type === 'redirect') {
+	// 		cancel();
+	// 		toast.success('Task created successfully!');
+	// 		await goto(result.location);
+	// 	}
+	// },
+	// onUpdate: ({ form }) => {
+	// 	if ($message?.type === 'error') {
+	// 		toast.error(`Error creating task. Reason: ${$message.text}`);
+	// 	}
+	// }
+	onUpdate: () => {
 		if ($message?.type === 'error') {
 			toast.error(`Error creating task. Reason: ${$message.text}`);
 		}
@@ -176,8 +186,12 @@ let selectedStateOption = $derived(
 				{/if}
 
 				<div class="flex gap-2">
-					<Button type="submit" class="text-white bg-orange-600 hover:bg-orange-700">
-						Create
+					<Button
+						type="submit"
+						disabled={$submitting}
+						class="text-white bg-orange-600 hover:bg-orange-700"
+					>
+						{$submitting ? 'Creating...' : 'Create'}
 					</Button>
 					<Button type="button" variant="outline" href="/tasks">Cancel</Button>
 				</div>


### PR DESCRIPTION
This pull request introduces several improvements to task and journal entry creation flows, focusing on better error handling, user feedback, and code consistency. The most significant changes enhance the robustness of database transactions, improve error reporting and logging, and provide clearer UI feedback to users during form submissions.

**Task Creation Improvements:**

* Refactored the `createTaskWithTaskNumber` function to use the new Drizzle ORM `.all()` API for synchronous transaction steps, improving reliability and compatibility with the latest Drizzle version. [[1]](diffhunk://#diff-59c01e7cad761f6e157373060e47468c07342a6396dbb07630bde136c53cd0bbL42-R62) [[2]](diffhunk://#diff-59c01e7cad761f6e157373060e47468c07342a6396dbb07630bde136c53cd0bbL75-R78)
* Updated error handling in the `/tasks/new` server action to use the `message` helper for user-friendly error messages, replacing the previous `fail` response. This ensures errors are communicated to the UI in a standardized way.
* Improved the task creation form UI: the submit button now shows a loading state (`Creating...`) and is disabled while submitting, providing better feedback to users.
* Enhanced the `superForm` usage in the task creation component to handle and display error messages via toast notifications, and prepared for future redirect handling.

**Journal Entry Improvements:**

* Improved error logging in journal entry creation by including the `userId` in error logs for better traceability.
* Removed a redundant warning log for invalid journal entry form data, reducing log noise.

**Error Logging Enhancements:**

* Enhanced the `Logger` utility to serialize non-Error objects more gracefully, capturing error details when possible instead of suppressing them.

**Minor Code Cleanups:**

* Removed an unused derived state (`isEditMode`) in the journal entry form component.
* Cleaned up imports and return values for consistency and clarity in the `/tasks/new` server code. [[1]](diffhunk://#diff-59c01e7cad761f6e157373060e47468c07342a6396dbb07630bde136c53cd0bbL3-R3) [[2]](diffhunk://#diff-59c01e7cad761f6e157373060e47468c07342a6396dbb07630bde136c53cd0bbL100-R103)