### PR TITLE
fix: prevent duplicate task names during creation and update

### DIFF
--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { and, eq, sql } from 'drizzle-orm';
-import { superValidate } from 'sveltekit-superforms';
+import { and, eq, ne, sql } from 'drizzle-orm';
+import { setError, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import {
@@ -87,6 +87,19 @@ export const actions: Actions = {
 
 		if (!form.valid) {
 			return fail(400, { form });
+		}
+
+		if (form.data.title) {
+			const duplicate = await getDb().query.tasks.findFirst({
+				where: and(
+					eq(tasks.userId, user.id),
+					eq(tasks.title, form.data.title),
+					ne(tasks.id, taskId)
+				)
+			});
+			if (duplicate) {
+				return setError(form, 'title', 'A task with this name already exists.');
+			}
 		}
 
 		try {

--- a/src/routes/(app)/tasks/new/+page.server.ts
+++ b/src/routes/(app)/tasks/new/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { and, eq, sql } from 'drizzle-orm';
-import { message, superValidate } from 'sveltekit-superforms';
+import { message, setError, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import { createTaskSchema, type TaskState, TaskStateEnum } from '$lib/schemas/task';
@@ -109,6 +109,13 @@ export const actions: Actions = {
 
 		if (!form.valid) {
 			return fail(400, { form });
+		}
+
+		const duplicate = await getDb().query.tasks.findFirst({
+			where: and(eq(tasks.userId, user.id), eq(tasks.title, form.data.title))
+		});
+		if (duplicate) {
+			return setError(form, 'title', 'A task with this name already exists.');
 		}
 
 		try {


### PR DESCRIPTION
This pull request introduces validation to prevent users from creating or editing tasks with duplicate titles. The main changes add checks for existing tasks with the same title and return a form error if a duplicate is found.

**Duplicate Task Title Validation:**

* On the task creation page (`+page.server.ts`), a check is added to prevent creating a new task with a title that already exists for the user. If a duplicate is found, an error is set on the form's `title` field.
* On the task edit page (`+page.server.ts`), a similar check ensures that when editing a task, the new title does not duplicate another task's title for the same user (excluding the task being edited). If a duplicate is found, an error is set on the `title` field. ([src/routes/(app)/tasks/[id]/edit/+page.server.tsR92-R104](diffhunk://#diff-bc07afd489d9c01ad3838e005f25a340c455541566017f7ff5a63748b61cc7ecR92-R104))

**Supporting Code Updates:**

* Imported the `setError` function from `sveltekit-superforms` in both the new and edit task server files to enable setting form errors when duplicates are detected. ([src/routes/(app)/tasks/new/+page.server.tsL3-R3](diffhunk://#diff-59c01e7cad761f6e157373060e47468c07342a6396dbb07630bde136c53cd0bbL3-R3), [src/routes/(app)/tasks/[id]/edit/+page.server.tsL2-R3](diffhunk://#diff-bc07afd489d9c01ad3838e005f25a340c455541566017f7ff5a63748b61cc7ecL2-R3))