### PR TITLE
style: adjust button size and padding in SiteHeader and JournalEntry components for improved layout

### DIFF
--- a/src/lib/components/app/SiteHeader.svelte
+++ b/src/lib/components/app/SiteHeader.svelte
@@ -103,7 +103,7 @@ let showBreadcrumbs = $derived(breadcrumbs.length > 1);
 			{/if}
 		</div>
 		<div class="ms-auto flex items-center gap-2">
-			<Button onclick={toggleMode} variant="outline" size="icon" class="h-9 w-9">
+			<Button onclick={toggleMode} variant="outline" size="icon" class="h-8 w-8">
 				<Sun
 					class="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all! dark:scale-0 dark:-rotate-90"
 				/>

--- a/src/lib/components/journal/JournalEntryEditor.svelte
+++ b/src/lib/components/journal/JournalEntryEditor.svelte
@@ -457,14 +457,14 @@ function insertLink(): void {
 			{/if}
 		</div>
 
-		<Tabs.Content value="write" class="p-3 md:p-4">
+		<Tabs.Content value="write" class="p-1 sm:p-3 md:p-4">
 			<Textarea
 				bind:ref={textareaRef}
 				bind:value={markdown}
 				id="content"
 				name="content"
 				{placeholder}
-				class="min-h-90 resize-y border-[oklch(var(--color-blue)/0.2)] bg-[oklch(var(--background))] font-mono text-[0.95rem] leading-6"
+				class="min-h-[55vh] resize-y border-[oklch(var(--color-blue)/0.2)] bg-[oklch(var(--background))] font-mono text-[0.95rem] leading-6 md:min-h-90"
 			/>
 		</Tabs.Content>
 

--- a/src/lib/components/journal/JournalEntryForm.svelte
+++ b/src/lib/components/journal/JournalEntryForm.svelte
@@ -71,7 +71,7 @@ async function getWeather() {
 }
 </script>
 
-<PageShell class="space-y-6 py-3 sm:py-6">
+<PageShell class="space-y-4 py-0 sm:py-6">
 	<SectionHeader
 		title={pageTitle}
 		description="A focused, distraction-light writing space designed for flow."
@@ -85,10 +85,15 @@ async function getWeather() {
 		</div>
 	</SectionHeader>
 
-	<ContentSection color="blue" border={true} padding="lg" class="overflow-hidden">
+	<ContentSection
+		color="blue"
+		border={false}
+		padding="none"
+		class="-mx-4 overflow-hidden sm:mx-0 sm:border-l-4 sm:border-[oklch(var(--color-blue))] sm:p-6 md:p-8"
+	>
 		<form method="POST" action={formAction} {@attach fromAction(enhance)} class="space-y-6">
 			<div
-				class="rounded-2xl border border-[oklch(var(--color-blue)/0.2)] bg-white/88 p-5 shadow-sm dark:bg-slate-950/72 md:p-7"
+				class="px-2 py-3 sm:rounded-2xl sm:border sm:border-[oklch(var(--color-blue)/0.2)] sm:bg-white/88 sm:p-5 sm:shadow-sm sm:dark:bg-slate-950/72 md:p-7"
 			>
 				<div class="space-y-2">
 					<h2 class="font-display text-2xl font-bold text-foreground md:text-3xl">Today's Story</h2>


### PR DESCRIPTION
This pull request makes several UI refinements to the journal entry and site header components, focusing on improving layout, padding, and responsiveness for a better user experience. The most notable changes involve adjusting spacing and border styles in the journal entry form, enhancing the textarea's usability, and making minor tweaks to button sizing.

**Journal Entry Form layout and style improvements:**

* Changed the outer `PageShell` padding and spacing to use smaller vertical spacing and no padding on mobile for a more compact appearance (`src/lib/components/journal/JournalEntryForm.svelte`).
* Updated the `ContentSection` to remove the border and padding by default, applying custom negative margins and responsive border and padding only on larger screens, resulting in a cleaner and more consistent layout across devices (`src/lib/components/journal/JournalEntryForm.svelte`).
* Modified the inner form container to apply padding and border-radius only on larger screens, making the form look less cluttered on mobile while retaining structure on desktop (`src/lib/components/journal/JournalEntryForm.svelte`).

**Journal Entry Editor textarea improvements:**

* Adjusted the write tab's padding to be smaller on mobile, and increased the textarea's minimum height to 55vh (viewport height) for better usability, with the previous minimum height retained on medium screens and above (`src/lib/components/journal/JournalEntryEditor.svelte`).

**Site Header button size adjustment:**

* Reduced the size of the mode toggle button for a more balanced appearance in the header (`src/lib/components/app/SiteHeader.svelte`).