### PR TITLE
Test hardening

### DIFF
--- a/src/lib/schemas/auth.test.ts
+++ b/src/lib/schemas/auth.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	changePasswordSchema,
+	forgotPasswordSchema,
+	loginSchema,
+	registerSchema,
+	resetPasswordSchema,
+	updateProfileSchema
+} from './auth';
+
+describe('registerSchema', () => {
+	const validPayload = {
+		name: 'Alice Smith',
+		email: 'alice@example.com',
+		password: 'SecurePass1!',
+		confirmPassword: 'SecurePass1!'
+	};
+
+	it('accepts a valid registration payload', () => {
+		expect(() => registerSchema.parse(validPayload)).not.toThrow();
+	});
+
+	it('rejects a name shorter than 2 characters', () => {
+		const result = registerSchema.safeParse({ ...validPayload, name: 'A' });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a name longer than 100 characters', () => {
+		const result = registerSchema.safeParse({ ...validPayload, name: 'A'.repeat(101) });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an invalid email address', () => {
+		const result = registerSchema.safeParse({ ...validPayload, email: 'not-an-email' });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a password shorter than 12 characters', () => {
+		const result = registerSchema.safeParse({
+			...validPayload,
+			password: 'Short1',
+			confirmPassword: 'Short1'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a password without an uppercase letter', () => {
+		const result = registerSchema.safeParse({
+			...validPayload,
+			password: 'alllowercase1!',
+			confirmPassword: 'alllowercase1!'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a password without a lowercase letter', () => {
+		const result = registerSchema.safeParse({
+			...validPayload,
+			password: 'ALLUPPERCASE1!',
+			confirmPassword: 'ALLUPPERCASE1!'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a password without a digit', () => {
+		const result = registerSchema.safeParse({
+			...validPayload,
+			password: 'NoDigitsHere!!',
+			confirmPassword: 'NoDigitsHere!!'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects when passwords do not match', () => {
+		const result = registerSchema.safeParse({
+			...validPayload,
+			confirmPassword: 'DifferentPass1!'
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((e) => e.path.join('.'));
+			expect(paths).toContain('confirmPassword');
+		}
+	});
+});
+
+describe('loginSchema', () => {
+	it('accepts valid credentials', () => {
+		expect(() =>
+			loginSchema.parse({ email: 'user@example.com', password: 'ValidPass123' })
+		).not.toThrow();
+	});
+
+	it('rejects an invalid email', () => {
+		const result = loginSchema.safeParse({ email: 'bad', password: 'ValidPass123' });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a password shorter than 12 characters', () => {
+		const result = loginSchema.safeParse({ email: 'user@example.com', password: 'short' });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('forgotPasswordSchema', () => {
+	it('accepts a valid email', () => {
+		expect(() => forgotPasswordSchema.parse({ email: 'user@example.com' })).not.toThrow();
+	});
+
+	it('rejects an invalid email', () => {
+		expect(forgotPasswordSchema.safeParse({ email: 'not-valid' }).success).toBe(false);
+	});
+});
+
+describe('resetPasswordSchema', () => {
+	const validReset = {
+		password: 'NewSecurePass1!',
+		confirmPassword: 'NewSecurePass1!',
+		token: 'abc123'
+	};
+
+	it('accepts a valid reset payload', () => {
+		expect(() => resetPasswordSchema.parse(validReset)).not.toThrow();
+	});
+
+	it('rejects when passwords do not match', () => {
+		const result = resetPasswordSchema.safeParse({
+			...validReset,
+			confirmPassword: 'Mismatch123!'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('token is optional', () => {
+		const { token: _token, ...withoutToken } = validReset;
+		expect(() => resetPasswordSchema.parse(withoutToken)).not.toThrow();
+	});
+});
+
+describe('updateProfileSchema', () => {
+	it('accepts a valid name', () => {
+		expect(() => updateProfileSchema.parse({ name: 'Alice' })).not.toThrow();
+	});
+
+	it('rejects an empty name', () => {
+		expect(updateProfileSchema.safeParse({ name: '' }).success).toBe(false);
+	});
+
+	it('rejects a name longer than 100 characters', () => {
+		expect(updateProfileSchema.safeParse({ name: 'A'.repeat(101) }).success).toBe(false);
+	});
+});
+
+describe('changePasswordSchema', () => {
+	it('accepts valid change password payload', () => {
+		expect(() =>
+			changePasswordSchema.parse({
+				currentPassword: 'OldPass123456',
+				newPassword: 'NewSecurePass1!',
+				confirmPassword: 'NewSecurePass1!'
+			})
+		).not.toThrow();
+	});
+
+	it('rejects when new passwords do not match', () => {
+		const result = changePasswordSchema.safeParse({
+			currentPassword: 'OldPass123456',
+			newPassword: 'NewPass12345!',
+			confirmPassword: 'Different123!'
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/lib/schemas/daily-agenda.test.ts
+++ b/src/lib/schemas/daily-agenda.test.ts
@@ -103,4 +103,42 @@ describe('daily agenda schemas', () => {
 
 		expect(result.success).toBe(false);
 	});
+
+	it('parses booleanish truthy strings as true', () => {
+		for (const truthy of ['true', '1', 'on', true] as const) {
+			const result = toggleDailyAgendaEntrySchema.parse({
+				id: '123e4567-e89b-12d3-a456-426614174000',
+				completed: truthy
+			});
+			expect(result.completed).toBe(true);
+		}
+	});
+
+	it('parses booleanish falsy strings as false', () => {
+		for (const falsy of ['false', '0', '', false] as const) {
+			const result = toggleDailyAgendaEntrySchema.parse({
+				id: '123e4567-e89b-12d3-a456-426614174000',
+				completed: falsy
+			});
+			expect(result.completed).toBe(false);
+		}
+	});
+
+	it('rejects invalid day number -1 in daysOfWeek', () => {
+		expect(
+			createDailyAgendaTemplateSchema.safeParse({
+				title: 'Walk outside',
+				daysOfWeek: '-1,1,2'
+			}).success
+		).toBe(false);
+	});
+
+	it('rejects invalid day number 7 in daysOfWeek', () => {
+		expect(
+			createDailyAgendaTemplateSchema.safeParse({
+				title: 'Walk outside',
+				daysOfWeek: '1,2,7'
+			}).success
+		).toBe(false);
+	});
 });

--- a/src/lib/schemas/fitness.test.ts
+++ b/src/lib/schemas/fitness.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	deleteEntrySchema,
+	logMealSchema,
+	logWeightSchema,
+	logWorkoutSchema,
+	setCalorieTargetSchema,
+	setGoalWeightSchema,
+	updateMealSchema,
+	updateWeightSchema,
+	updateWorkoutSchema
+} from './fitness';
+
+describe('logWeightSchema', () => {
+	it('accepts a valid weight log entry', () => {
+		expect(() => logWeightSchema.parse({ date: '2026-03-15', weightLbs: 185.5 })).not.toThrow();
+	});
+
+	it('accepts an optional time field', () => {
+		const result = logWeightSchema.parse({ date: '2026-03-15', time: '07:30', weightLbs: 185 });
+		expect(result.time).toBe('07:30');
+	});
+
+	it('rejects a non-positive weight', () => {
+		expect(logWeightSchema.safeParse({ date: '2026-03-15', weightLbs: 0 }).success).toBe(false);
+		expect(logWeightSchema.safeParse({ date: '2026-03-15', weightLbs: -1 }).success).toBe(false);
+	});
+
+	it('coerces a string weight to a number', () => {
+		const result = logWeightSchema.parse({ date: '2026-03-15', weightLbs: '170.5' });
+		expect(result.weightLbs).toBe(170.5);
+	});
+
+	it('rejects an invalid date format', () => {
+		expect(logWeightSchema.safeParse({ date: 'March 15', weightLbs: 185 }).success).toBe(false);
+	});
+
+	it('rejects an invalid time format', () => {
+		expect(
+			logWeightSchema.safeParse({ date: '2026-03-15', time: '7:30am', weightLbs: 185 }).success
+		).toBe(false);
+	});
+});
+
+describe('updateWeightSchema', () => {
+	it('requires an id field', () => {
+		expect(updateWeightSchema.safeParse({ date: '2026-03-15', weightLbs: 185 }).success).toBe(
+			false
+		);
+	});
+
+	it('accepts a valid update payload with a UUID id', () => {
+		expect(() =>
+			updateWeightSchema.parse({
+				id: '123e4567-e89b-12d3-a456-426614174000',
+				date: '2026-03-15',
+				weightLbs: 185
+			})
+		).not.toThrow();
+	});
+});
+
+describe('setGoalWeightSchema', () => {
+	it('accepts a positive target weight', () => {
+		expect(() => setGoalWeightSchema.parse({ targetWeightLbs: 170 })).not.toThrow();
+	});
+
+	it('rejects zero and negative weights', () => {
+		expect(setGoalWeightSchema.safeParse({ targetWeightLbs: 0 }).success).toBe(false);
+		expect(setGoalWeightSchema.safeParse({ targetWeightLbs: -5 }).success).toBe(false);
+	});
+});
+
+describe('logWorkoutSchema', () => {
+	it('accepts a valid workout with required fields', () => {
+		expect(() => logWorkoutSchema.parse({ date: '2026-03-15', type: 'cardio' })).not.toThrow();
+	});
+
+	it('accepts all workout types', () => {
+		for (const type of ['strength', 'cardio', 'hiit', 'walk', 'stretch', 'other'] as const) {
+			expect(() => logWorkoutSchema.parse({ date: '2026-03-15', type })).not.toThrow();
+		}
+	});
+
+	it('rejects an unknown workout type', () => {
+		expect(logWorkoutSchema.safeParse({ date: '2026-03-15', type: 'yoga' }).success).toBe(false);
+	});
+
+	it('coerces durationMinutes to an integer', () => {
+		const result = logWorkoutSchema.parse({
+			date: '2026-03-15',
+			type: 'walk',
+			durationMinutes: '45'
+		});
+		expect(result.durationMinutes).toBe(45);
+	});
+
+	it('rejects a non-positive durationMinutes', () => {
+		expect(
+			logWorkoutSchema.safeParse({ date: '2026-03-15', type: 'walk', durationMinutes: 0 }).success
+		).toBe(false);
+	});
+});
+
+describe('updateWorkoutSchema', () => {
+	it('requires a valid UUID id', () => {
+		expect(updateWorkoutSchema.safeParse({ date: '2026-03-15', type: 'cardio' }).success).toBe(
+			false
+		);
+	});
+});
+
+describe('logMealSchema', () => {
+	it('accepts a valid meal entry', () => {
+		expect(() =>
+			logMealSchema.parse({
+				date: '2026-03-15',
+				timeOfDay: 'breakfast',
+				description: 'Oatmeal with berries'
+			})
+		).not.toThrow();
+	});
+
+	it('accepts all meal types', () => {
+		for (const timeOfDay of ['breakfast', 'lunch', 'dinner', 'snack'] as const) {
+			expect(() =>
+				logMealSchema.parse({ date: '2026-03-15', timeOfDay, description: 'Some food' })
+			).not.toThrow();
+		}
+	});
+
+	it('rejects an unknown meal type', () => {
+		expect(
+			logMealSchema.safeParse({ date: '2026-03-15', timeOfDay: 'brunch', description: 'Food' })
+				.success
+		).toBe(false);
+	});
+
+	it('rejects an empty description', () => {
+		expect(
+			logMealSchema.safeParse({ date: '2026-03-15', timeOfDay: 'lunch', description: '' }).success
+		).toBe(false);
+	});
+
+	it('coerces caloriesEstimate from string', () => {
+		const result = logMealSchema.parse({
+			date: '2026-03-15',
+			timeOfDay: 'lunch',
+			description: 'Salad',
+			caloriesEstimate: '400'
+		});
+		expect(result.caloriesEstimate).toBe(400);
+	});
+});
+
+describe('updateMealSchema', () => {
+	it('requires a UUID id', () => {
+		expect(
+			updateMealSchema.safeParse({ date: '2026-03-15', timeOfDay: 'lunch', description: 'Food' })
+				.success
+		).toBe(false);
+	});
+});
+
+describe('setCalorieTargetSchema', () => {
+	it('accepts a positive calorie target', () => {
+		expect(() => setCalorieTargetSchema.parse({ targetCalories: 2000 })).not.toThrow();
+	});
+
+	it('rejects zero and negative values', () => {
+		expect(setCalorieTargetSchema.safeParse({ targetCalories: 0 }).success).toBe(false);
+		expect(setCalorieTargetSchema.safeParse({ targetCalories: -500 }).success).toBe(false);
+	});
+
+	it('coerces string numbers', () => {
+		const result = setCalorieTargetSchema.parse({ targetCalories: '2000' });
+		expect(result.targetCalories).toBe(2000);
+	});
+});
+
+describe('deleteEntrySchema', () => {
+	it('accepts a valid UUID', () => {
+		expect(() =>
+			deleteEntrySchema.parse({ id: '123e4567-e89b-12d3-a456-426614174000' })
+		).not.toThrow();
+	});
+
+	it('rejects a non-UUID id', () => {
+		expect(deleteEntrySchema.safeParse({ id: 'not-a-uuid' }).success).toBe(false);
+	});
+});

--- a/src/lib/schemas/journal.test.ts
+++ b/src/lib/schemas/journal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { journalEntrySchema, journalFilterSchema } from './journal';
+
+describe('journalEntrySchema', () => {
+	const validEntry = {
+		date: '2026-03-15',
+		content: 'Today was productive.',
+		location: 'Home',
+		weatherTemp: 72,
+		weatherCondition: 'Sunny'
+	};
+
+	it('accepts a valid journal entry', () => {
+		expect(() => journalEntrySchema.parse(validEntry)).not.toThrow();
+	});
+
+	it('accepts an entry without optional fields', () => {
+		expect(() =>
+			journalEntrySchema.parse({ date: '2026-03-15', content: 'Minimal entry.' })
+		).not.toThrow();
+	});
+
+	it('rejects an invalid date format', () => {
+		const result = journalEntrySchema.safeParse({ ...validEntry, date: '15-03-2026' });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an entry with no content', () => {
+		const result = journalEntrySchema.safeParse({ ...validEntry, content: '' });
+		expect(result.success).toBe(false);
+	});
+
+	it('coerces weatherTemp to a number', () => {
+		const result = journalEntrySchema.parse({ ...validEntry, weatherTemp: '68' });
+		expect(result.weatherTemp).toBe(68);
+	});
+});
+
+describe('journalFilterSchema', () => {
+	it('accepts an empty filter object and applies defaults', () => {
+		const result = journalFilterSchema.parse({});
+		expect(result.limit).toBe(50);
+	});
+
+	it('accepts content and date filters', () => {
+		const result = journalFilterSchema.parse({ content: 'walk', date: '2026-03-01' });
+		expect(result.content).toBe('walk');
+		expect(result.date).toBe('2026-03-01');
+	});
+
+	it('rejects a limit below 1', () => {
+		expect(journalFilterSchema.safeParse({ limit: 0 }).success).toBe(false);
+	});
+
+	it('rejects a limit above 100', () => {
+		expect(journalFilterSchema.safeParse({ limit: 101 }).success).toBe(false);
+	});
+
+	it('rejects an invalid date format in the filter', () => {
+		expect(journalFilterSchema.safeParse({ date: 'not-a-date' }).success).toBe(false);
+	});
+});

--- a/src/lib/schemas/meditation.test.ts
+++ b/src/lib/schemas/meditation.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	completeSessionSchema,
+	createRoutineSchema,
+	editSessionSchema,
+	routineFilterSchema,
+	scheduleSchema,
+	updateRoutineSchema
+} from './meditation';
+
+const validRoutine = {
+	title: 'Morning Calm',
+	link_url: 'https://example.com/meditation',
+	duration_minutes: 15,
+	mood_tags: 'Calm, Focused'
+};
+
+describe('createRoutineSchema', () => {
+	it('accepts a valid routine payload', () => {
+		expect(() => createRoutineSchema.parse(validRoutine)).not.toThrow();
+	});
+
+	it('rejects an empty title', () => {
+		expect(createRoutineSchema.safeParse({ ...validRoutine, title: '' }).success).toBe(false);
+	});
+
+	it('rejects a title longer than 100 characters', () => {
+		expect(createRoutineSchema.safeParse({ ...validRoutine, title: 'T'.repeat(101) }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects an invalid URL', () => {
+		expect(createRoutineSchema.safeParse({ ...validRoutine, link_url: 'not-a-url' }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects a non-positive duration', () => {
+		expect(createRoutineSchema.safeParse({ ...validRoutine, duration_minutes: 0 }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects empty mood tags', () => {
+		expect(createRoutineSchema.safeParse({ ...validRoutine, mood_tags: '' }).success).toBe(false);
+	});
+
+	it('accepts an optional description', () => {
+		const result = createRoutineSchema.parse({
+			...validRoutine,
+			description: 'A relaxing session'
+		});
+		expect(result.description).toBe('A relaxing session');
+	});
+});
+
+describe('updateRoutineSchema', () => {
+	it('accepts a valid update payload', () => {
+		expect(() => updateRoutineSchema.parse(validRoutine)).not.toThrow();
+	});
+
+	it('rejects an invalid URL in update', () => {
+		expect(
+			updateRoutineSchema.safeParse({ ...validRoutine, link_url: 'not-a-valid-url' }).success
+		).toBe(false);
+	});
+});
+
+describe('scheduleSchema', () => {
+	it('accepts daily cadence with a valid time', () => {
+		expect(() => scheduleSchema.parse({ cadence: 'daily', time: '07:00' })).not.toThrow();
+	});
+
+	it('accepts weekly cadence with days_of_week', () => {
+		expect(() =>
+			scheduleSchema.parse({ cadence: 'weekly', days_of_week: '[1,3,5]', time: '08:30' })
+		).not.toThrow();
+	});
+
+	it('rejects an invalid cadence value', () => {
+		expect(scheduleSchema.safeParse({ cadence: 'hourly', time: '09:00' }).success).toBe(false);
+	});
+
+	it('rejects an invalid time format', () => {
+		expect(scheduleSchema.safeParse({ cadence: 'daily', time: '9am' }).success).toBe(false);
+		expect(scheduleSchema.safeParse({ cadence: 'daily', time: '09:0' }).success).toBe(false);
+	});
+});
+
+describe('completeSessionSchema', () => {
+	it('accepts a valid session completion payload', () => {
+		expect(() =>
+			completeSessionSchema.parse({ completed_at: '2026-03-15T08:00:00.000Z' })
+		).not.toThrow();
+	});
+
+	it('accepts mood ratings within bounds', () => {
+		expect(() =>
+			completeSessionSchema.parse({
+				completed_at: '2026-03-15T08:00:00.000Z',
+				pre_mood_rating: 1,
+				mood_rating: 5
+			})
+		).not.toThrow();
+	});
+
+	it('rejects mood ratings outside 1-5 range', () => {
+		expect(
+			completeSessionSchema.safeParse({
+				completed_at: '2026-03-15T08:00:00.000Z',
+				mood_rating: 0
+			}).success
+		).toBe(false);
+
+		expect(
+			completeSessionSchema.safeParse({
+				completed_at: '2026-03-15T08:00:00.000Z',
+				mood_rating: 6
+			}).success
+		).toBe(false);
+	});
+
+	it('rejects an empty completed_at', () => {
+		expect(completeSessionSchema.safeParse({ completed_at: '' }).success).toBe(false);
+	});
+});
+
+describe('editSessionSchema', () => {
+	it('accepts a valid edit session payload', () => {
+		expect(() =>
+			editSessionSchema.parse({
+				id: 'session_123',
+				completed_at: '2026-03-15T08:00:00.000Z'
+			})
+		).not.toThrow();
+	});
+
+	it('rejects an empty id', () => {
+		expect(
+			editSessionSchema.safeParse({ id: '', completed_at: '2026-03-15T08:00:00Z' }).success
+		).toBe(false);
+	});
+});
+
+describe('routineFilterSchema', () => {
+	it('accepts an empty filter', () => {
+		expect(() => routineFilterSchema.parse({})).not.toThrow();
+	});
+
+	it('accepts valid mood array and duration', () => {
+		const result = routineFilterSchema.parse({ moods: ['Anxious', 'Focused'], duration: 15 });
+		expect(result.moods).toEqual(['Anxious', 'Focused']);
+		expect(result.duration).toBe(15);
+	});
+
+	it('rejects an invalid mood tag value', () => {
+		expect(routineFilterSchema.safeParse({ moods: ['UnknownMood'] }).success).toBe(false);
+	});
+
+	it('rejects a search string longer than 200 characters', () => {
+		expect(routineFilterSchema.safeParse({ search: 'x'.repeat(201) }).success).toBe(false);
+	});
+});

--- a/src/lib/schemas/mood.test.ts
+++ b/src/lib/schemas/mood.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { moodLogSchema, moodPeriodSchema } from './mood';
+
+describe('moodLogSchema', () => {
+	const validLog = {
+		date: '2026-03-15',
+		mood: 'happy',
+		customMood: '',
+		notes: ''
+	};
+
+	it('accepts a valid mood log entry', () => {
+		expect(() => moodLogSchema.parse(validLog)).not.toThrow();
+	});
+
+	it('applies default empty strings for customMood and notes', () => {
+		const result = moodLogSchema.parse({ date: '2026-03-15', mood: 'calm' });
+		expect(result.customMood).toBe('');
+		expect(result.notes).toBe('');
+	});
+
+	it('rejects an invalid mood value', () => {
+		const result = moodLogSchema.safeParse({ ...validLog, mood: 'ecstatic' });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe('Choose a valid mood');
+		}
+	});
+
+	it('rejects a custom mood without a custom label', () => {
+		const result = moodLogSchema.safeParse({ ...validLog, mood: 'custom', customMood: '' });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((e) => e.path.join('.'));
+			expect(paths).toContain('customMood');
+		}
+	});
+
+	it('accepts a custom mood with a valid label', () => {
+		const result = moodLogSchema.parse({ ...validLog, mood: 'custom', customMood: 'Grateful' });
+		expect(result.customMood).toBe('Grateful');
+	});
+
+	it('trims whitespace from customMood and notes', () => {
+		const result = moodLogSchema.parse({
+			...validLog,
+			mood: 'custom',
+			customMood: '  Grateful  ',
+			notes: '  Felt good  '
+		});
+		expect(result.customMood).toBe('Grateful');
+		expect(result.notes).toBe('Felt good');
+	});
+
+	it('rejects a customMood label exceeding 40 characters', () => {
+		const result = moodLogSchema.safeParse({
+			...validLog,
+			mood: 'custom',
+			customMood: 'A'.repeat(41)
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects notes exceeding 280 characters', () => {
+		const result = moodLogSchema.safeParse({ ...validLog, notes: 'x'.repeat(281) });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an invalid date format', () => {
+		expect(moodLogSchema.safeParse({ ...validLog, date: '03/15/2026' }).success).toBe(false);
+	});
+});
+
+describe('moodPeriodSchema', () => {
+	it('accepts valid mood periods', () => {
+		expect(() => moodPeriodSchema.parse('week')).not.toThrow();
+		expect(() => moodPeriodSchema.parse('month')).not.toThrow();
+		expect(() => moodPeriodSchema.parse('quarter')).not.toThrow();
+	});
+
+	it('rejects invalid period values', () => {
+		expect(moodPeriodSchema.safeParse('year').success).toBe(false);
+		expect(moodPeriodSchema.safeParse('').success).toBe(false);
+	});
+});

--- a/src/lib/schemas/task.test.ts
+++ b/src/lib/schemas/task.test.ts
@@ -138,4 +138,31 @@ describe('task schemas', () => {
 
 		expect(result.success).toBe(false);
 	});
+
+	it('rejects priority 0 which is below the minimum of 1', () => {
+		expect(createTaskSchema.safeParse({ title: 'Task', priority: 0 }).success).toBe(false);
+	});
+
+	it('rejects priority 5 which is above the maximum of 4', () => {
+		expect(createTaskSchema.safeParse({ title: 'Task', priority: 5 }).success).toBe(false);
+	});
+
+	it('rejects an invalid dueDate format', () => {
+		expect(
+			createTaskSchema.safeParse({ title: 'Task', priority: 2, dueDate: '03/15/2026' }).success
+		).toBe(false);
+	});
+
+	it('accepts a null dueDate', () => {
+		const result = createTaskSchema.parse({ title: 'Task', priority: 2, dueDate: null });
+		expect(result.dueDate).toBeNull();
+	});
+
+	it('rejects a title that exceeds 200 characters', () => {
+		expect(createTaskSchema.safeParse({ title: 'T'.repeat(201), priority: 1 }).success).toBe(false);
+	});
+
+	it('rejects an empty title', () => {
+		expect(createTaskSchema.safeParse({ title: '', priority: 1 }).success).toBe(false);
+	});
 });

--- a/src/lib/schemas/visits.test.ts
+++ b/src/lib/schemas/visits.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { personSchema, visitSchema } from './visits';
+
+describe('personSchema', () => {
+	it('accepts a valid person with a name', () => {
+		expect(() => personSchema.parse({ name: 'Alice' })).not.toThrow();
+	});
+
+	it('defaults isExempt to false when not provided', () => {
+		const result = personSchema.parse({ name: 'Alice' });
+		expect(result.isExempt).toBe(false);
+	});
+
+	it('rejects an empty name', () => {
+		expect(personSchema.safeParse({ name: '' }).success).toBe(false);
+	});
+
+	it('rejects a name longer than 100 characters', () => {
+		expect(personSchema.safeParse({ name: 'A'.repeat(101) }).success).toBe(false);
+	});
+
+	describe('isExempt booleanFromForm preprocessing', () => {
+		it('accepts boolean true directly', () => {
+			expect(personSchema.parse({ name: 'Alice', isExempt: true }).isExempt).toBe(true);
+		});
+
+		it('accepts boolean false directly', () => {
+			expect(personSchema.parse({ name: 'Alice', isExempt: false }).isExempt).toBe(false);
+		});
+
+		it('coerces truthy string values to true', () => {
+			for (const truthy of ['true', 'on', '1']) {
+				expect(personSchema.parse({ name: 'Alice', isExempt: truthy }).isExempt).toBe(true);
+			}
+		});
+
+		it('coerces falsy string values to false', () => {
+			for (const falsy of ['false', '0', '']) {
+				expect(personSchema.parse({ name: 'Alice', isExempt: falsy }).isExempt).toBe(false);
+			}
+		});
+
+		it('coerces undefined and null to false', () => {
+			expect(personSchema.parse({ name: 'Alice', isExempt: undefined }).isExempt).toBe(false);
+			expect(personSchema.parse({ name: 'Alice', isExempt: null }).isExempt).toBe(false);
+		});
+	});
+});
+
+describe('visitSchema', () => {
+	it('accepts a valid visit with required fields', () => {
+		expect(() => visitSchema.parse({ date: '2026-03-15' })).not.toThrow();
+	});
+
+	it('accepts a visit with all optional fields', () => {
+		expect(() =>
+			visitSchema.parse({
+				date: '2026-03-15',
+				time: '14:00',
+				companions: 'Bob, Carol',
+				notes: 'Good visit',
+				followUpDate: '2026-06-15'
+			})
+		).not.toThrow();
+	});
+
+	it('rejects an invalid date format', () => {
+		expect(visitSchema.safeParse({ date: '15-03-2026' }).success).toBe(false);
+	});
+
+	it('rejects an invalid time format', () => {
+		expect(visitSchema.safeParse({ date: '2026-03-15', time: '2pm' }).success).toBe(false);
+	});
+
+	it('rejects an invalid followUpDate format', () => {
+		expect(visitSchema.safeParse({ date: '2026-03-15', followUpDate: 'next-week' }).success).toBe(
+			false
+		);
+	});
+
+	it('treats an empty string followUpDate as undefined (no follow-up)', () => {
+		const result = visitSchema.parse({ date: '2026-03-15', followUpDate: '' });
+		expect(result.followUpDate).toBeUndefined();
+	});
+});

--- a/src/lib/server/actions/auth-guard.test.ts
+++ b/src/lib/server/actions/auth-guard.test.ts
@@ -1,0 +1,77 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { isRedirect } from '@sveltejs/kit';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getUser, requireAuth } from './auth-guard';
+
+type MockLocals = App.Locals;
+
+function makeLocals(overrides: Partial<MockLocals> = {}): MockLocals {
+	return {
+		user: undefined,
+		session: undefined,
+		requestId: 'test-request-id',
+		...overrides
+	};
+}
+
+function makeEvent(overrides: Partial<MockLocals> = {}): RequestEvent {
+	return { locals: makeLocals(overrides) } as unknown as RequestEvent;
+}
+
+const mockUser = { id: 'user_123', name: 'Alice', email: 'alice@example.com' };
+
+describe('requireAuth', () => {
+	it('returns fail(401) when the user is not authenticated', async () => {
+		const wrapped = requireAuth(async () => ({ ok: true }));
+		const result = await wrapped(makeEvent());
+
+		expect(result).toMatchObject({ status: 401 });
+	});
+
+	it('calls the handler and returns its result when the user is authenticated', async () => {
+		const handler = vi.fn().mockResolvedValue({ success: true });
+		const wrapped = requireAuth(handler);
+
+		const result = await wrapped(makeEvent({ user: mockUser as App.Locals['user'] }));
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler).toHaveBeenCalledWith(
+			expect.objectContaining({ locals: expect.anything() }),
+			mockUser
+		);
+		expect(result).toEqual({ success: true });
+	});
+
+	it('passes the authenticated user as the second argument to the handler', async () => {
+		let capturedUser: unknown;
+		const wrapped = requireAuth(async (_event, user) => {
+			capturedUser = user;
+			return null;
+		});
+
+		await wrapped(makeEvent({ user: mockUser as App.Locals['user'] }));
+
+		expect(capturedUser).toBe(mockUser);
+	});
+});
+
+describe('getUser', () => {
+	it('returns the user from locals when authenticated', () => {
+		const locals = makeLocals({ user: mockUser as App.Locals['user'] });
+		const user = getUser(locals);
+		expect(user).toBe(mockUser);
+	});
+
+	it('throws a redirect to /sign-in when the user is missing', () => {
+		const locals = makeLocals({ user: undefined });
+
+		expect(() => getUser(locals)).toThrow();
+
+		try {
+			getUser(locals);
+		} catch (e) {
+			expect(isRedirect(e)).toBe(true);
+		}
+	});
+});

--- a/src/lib/server/actions/edit-route-helpers.test.ts
+++ b/src/lib/server/actions/edit-route-helpers.test.ts
@@ -1,0 +1,109 @@
+import { isHttpError, isRedirect } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+
+import { getOwnedEntityOrNull, getOwnedEntityOrThrow } from './edit-route-helpers';
+
+describe('getOwnedEntityOrThrow', () => {
+	it('returns the entity when found', async () => {
+		const entity = { id: 'entity_1', name: 'Test' };
+		const result = await getOwnedEntityOrThrow(async () => entity, {
+			type: 'error',
+			message: 'Not found'
+		});
+
+		expect(result).toBe(entity);
+	});
+
+	it('throws a redirect when the entity is not found and behavior is redirect', async () => {
+		expect.assertions(2);
+
+		try {
+			await getOwnedEntityOrThrow(async () => undefined, {
+				type: 'redirect',
+				to: '/tasks'
+			});
+		} catch (e) {
+			expect(isRedirect(e)).toBe(true);
+			if (isRedirect(e)) {
+				expect(e.location).toBe('/tasks');
+			}
+		}
+	});
+
+	it('uses the provided redirect status code', async () => {
+		expect.assertions(2);
+
+		try {
+			await getOwnedEntityOrThrow(async () => undefined, {
+				type: 'redirect',
+				to: '/tasks',
+				status: 301
+			});
+		} catch (e) {
+			expect(isRedirect(e)).toBe(true);
+			if (isRedirect(e)) {
+				expect(e.status).toBe(301);
+			}
+		}
+	});
+
+	it('defaults redirect status to 303 when not specified', async () => {
+		expect.assertions(1);
+
+		try {
+			await getOwnedEntityOrThrow(async () => undefined, {
+				type: 'redirect',
+				to: '/home'
+			});
+		} catch (e) {
+			if (isRedirect(e)) {
+				expect(e.status).toBe(303);
+			}
+		}
+	});
+
+	it('throws an HTTP error when the entity is not found and behavior is error', async () => {
+		expect.assertions(2);
+
+		try {
+			await getOwnedEntityOrThrow(async () => undefined, {
+				type: 'error',
+				message: 'Task not found'
+			});
+		} catch (e) {
+			expect(isHttpError(e)).toBe(true);
+			if (isHttpError(e)) {
+				expect(e.status).toBe(404);
+			}
+		}
+	});
+
+	it('uses the provided error status code', async () => {
+		expect.assertions(1);
+
+		try {
+			await getOwnedEntityOrThrow(async () => undefined, {
+				type: 'error',
+				message: 'Forbidden',
+				status: 403
+			});
+		} catch (e) {
+			if (isHttpError(e)) {
+				expect(e.status).toBe(403);
+			}
+		}
+	});
+});
+
+describe('getOwnedEntityOrNull', () => {
+	it('returns the entity when found', async () => {
+		const entity = { id: 'entity_1' };
+		const result = await getOwnedEntityOrNull(async () => entity);
+		expect(result).toBe(entity);
+	});
+
+	it('returns null when the entity is not found', async () => {
+		const result = await getOwnedEntityOrNull(async () => undefined);
+		expect(result).toBeNull();
+	});
+});

--- a/src/lib/server/actions/string-parsers.test.ts
+++ b/src/lib/server/actions/string-parsers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitCommaSeparated, toCommaSeparatedJson } from './string-parsers';
+
+describe('splitCommaSeparated', () => {
+	it('splits a comma-separated string into trimmed items', () => {
+		expect(splitCommaSeparated('a, b, c')).toEqual(['a', 'b', 'c']);
+		expect(splitCommaSeparated('one,two,three')).toEqual(['one', 'two', 'three']);
+	});
+
+	it('trims whitespace around each item', () => {
+		expect(splitCommaSeparated('  hello ,   world  ')).toEqual(['hello', 'world']);
+	});
+
+	it('filters out empty items produced by trailing commas', () => {
+		expect(splitCommaSeparated('a,,b,')).toEqual(['a', 'b']);
+	});
+
+	it('returns an empty array for null, undefined, and empty string', () => {
+		expect(splitCommaSeparated(null)).toEqual([]);
+		expect(splitCommaSeparated(undefined)).toEqual([]);
+		expect(splitCommaSeparated('')).toEqual([]);
+	});
+
+	it('returns a single-item array when there is no comma', () => {
+		expect(splitCommaSeparated('only')).toEqual(['only']);
+	});
+
+	it('returns an empty array for a whitespace-only string', () => {
+		expect(splitCommaSeparated('   ')).toEqual([]);
+	});
+});
+
+describe('toCommaSeparatedJson', () => {
+	it('serializes items to a JSON array string', () => {
+		expect(toCommaSeparatedJson('alpha, beta, gamma')).toBe('["alpha","beta","gamma"]');
+	});
+
+	it('returns null when the input is null, undefined, or empty', () => {
+		expect(toCommaSeparatedJson(null)).toBeNull();
+		expect(toCommaSeparatedJson(undefined)).toBeNull();
+		expect(toCommaSeparatedJson('')).toBeNull();
+	});
+
+	it('returns null when all parts are whitespace', () => {
+		expect(toCommaSeparatedJson('  ,  ,  ')).toBeNull();
+	});
+
+	it('returns a single-element JSON array for a single value', () => {
+		expect(toCommaSeparatedJson('item')).toBe('["item"]');
+	});
+});

--- a/src/lib/server/auth/form-helpers.test.ts
+++ b/src/lib/server/auth/form-helpers.test.ts
@@ -1,0 +1,59 @@
+import { isRedirect, redirect } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+
+import { mapAuthActionError, redirectIfAuthenticated } from './form-helpers';
+
+const mockUser = { id: 'user_123', name: 'Alice', email: 'alice@example.com' };
+
+describe('redirectIfAuthenticated', () => {
+	it('throws a redirect to /dashboard when the user is authenticated', () => {
+		expect.assertions(2);
+
+		try {
+			redirectIfAuthenticated(mockUser as App.Locals['user']);
+		} catch (e) {
+			expect(isRedirect(e)).toBe(true);
+			if (isRedirect(e)) {
+				expect(e.location).toBe('/dashboard');
+			}
+		}
+	});
+
+	it('does not throw when the user is null', () => {
+		expect(() => redirectIfAuthenticated(undefined)).not.toThrow();
+	});
+
+	it('does not throw when the user is undefined', () => {
+		expect(() => redirectIfAuthenticated(undefined)).not.toThrow();
+	});
+});
+
+describe('mapAuthActionError', () => {
+	it('re-throws a redirect error unchanged', () => {
+		// Create a redirect via the SvelteKit helper, which throws
+		let redirectError: unknown;
+		try {
+			redirect(302, '/sign-in');
+		} catch (e) {
+			redirectError = e;
+		}
+
+		expect.assertions(1);
+		try {
+			mapAuthActionError(redirectError, 'fallback message');
+		} catch (e) {
+			expect(isRedirect(e)).toBe(true);
+		}
+	});
+
+	it('returns the fallback message for non-redirect errors', () => {
+		const result = mapAuthActionError(new Error('some error'), 'Sign-in failed');
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it('returns the fallback message for unknown errors', () => {
+		const result = mapAuthActionError('unexpected', 'Default error message');
+		expect(typeof result).toBe('string');
+	});
+});

--- a/src/lib/server/daily-agenda.test.ts
+++ b/src/lib/server/daily-agenda.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	assertDateIsEditable,
+	buildDateRangeLabel,
+	calculateCompletionPercentage,
+	DailyAgendaMutationError,
+	getEntriesToDeleteForDays,
+	normalizeTemplateDays,
+	parseTemplateDays,
+	serializeTemplateDays
+} from './daily-agenda';
+
+const EVERY_DAY = [0, 1, 2, 3, 4, 5, 6];
+
+describe('calculateCompletionPercentage', () => {
+	it('returns 0 for an empty list', () => {
+		expect(calculateCompletionPercentage([])).toBe(0);
+	});
+
+	it('returns 100 when all entries are completed', () => {
+		const entries = [{ completed: true }, { completed: true }, { completed: true }];
+		expect(calculateCompletionPercentage(entries)).toBe(100);
+	});
+
+	it('returns 0 when no entries are completed', () => {
+		const entries = [{ completed: false }, { completed: false }];
+		expect(calculateCompletionPercentage(entries)).toBe(0);
+	});
+
+	it('calculates the percentage and rounds to the nearest integer', () => {
+		const entries = [{ completed: true }, { completed: true }, { completed: false }];
+		expect(calculateCompletionPercentage(entries)).toBe(67);
+	});
+
+	it('rounds correctly for one out of four', () => {
+		const entries = [
+			{ completed: true },
+			{ completed: false },
+			{ completed: false },
+			{ completed: false }
+		];
+		expect(calculateCompletionPercentage(entries)).toBe(25);
+	});
+});
+
+describe('buildDateRangeLabel', () => {
+	it('formats a date range with month and year on the end date', () => {
+		const label = buildDateRangeLabel('2026-03-02', '2026-03-08');
+		expect(label).toContain('Mar 2');
+		expect(label).toContain('Mar 8');
+		expect(label).toContain('2026');
+	});
+
+	it('handles a range spanning two months', () => {
+		const label = buildDateRangeLabel('2026-03-30', '2026-04-05');
+		expect(label).toContain('Mar');
+		expect(label).toContain('Apr');
+		expect(label).toContain('2026');
+	});
+
+	it('uses " - " as the separator', () => {
+		const label = buildDateRangeLabel('2026-03-02', '2026-03-08');
+		expect(label).toContain(' - ');
+	});
+});
+
+describe('normalizeTemplateDays', () => {
+	it('returns sorted, deduplicated days', () => {
+		expect(normalizeTemplateDays([3, 1, 3, 0])).toEqual([0, 1, 3]);
+	});
+
+	it('filters out days outside 0-6', () => {
+		expect(normalizeTemplateDays([0, 7, -1, 6])).toEqual([0, 6]);
+	});
+
+	it('returns every day as fallback when the input is empty', () => {
+		expect(normalizeTemplateDays([])).toEqual(EVERY_DAY);
+	});
+
+	it('returns every day as fallback when all values are invalid', () => {
+		expect(normalizeTemplateDays([7, 8, -1])).toEqual(EVERY_DAY);
+	});
+
+	it('accepts all days 0-6', () => {
+		expect(normalizeTemplateDays([0, 1, 2, 3, 4, 5, 6])).toEqual(EVERY_DAY);
+	});
+});
+
+describe('parseTemplateDays', () => {
+	it('parses a valid JSON array of days', () => {
+		expect(parseTemplateDays('[1, 3, 5]')).toEqual([1, 3, 5]);
+	});
+
+	it('deduplicates and sorts the parsed days', () => {
+		expect(parseTemplateDays('[5, 1, 5, 3]')).toEqual([1, 3, 5]);
+	});
+
+	it('falls back to every day when the JSON is invalid', () => {
+		expect(parseTemplateDays('not-json')).toEqual(EVERY_DAY);
+		expect(parseTemplateDays('')).toEqual(EVERY_DAY);
+	});
+
+	it('falls back to every day when JSON is not an array', () => {
+		expect(parseTemplateDays('"string"')).toEqual(EVERY_DAY);
+		expect(parseTemplateDays('42')).toEqual(EVERY_DAY);
+	});
+
+	it('filters non-numeric values in the parsed array', () => {
+		expect(parseTemplateDays('[1, "bad", 3, null]')).toEqual([1, 3]);
+	});
+});
+
+describe('serializeTemplateDays', () => {
+	it('serializes a valid set of days to a JSON string', () => {
+		expect(serializeTemplateDays([1, 3, 5])).toBe('[1,3,5]');
+	});
+
+	it('deduplicates and sorts before serializing', () => {
+		expect(serializeTemplateDays([5, 1, 5, 3])).toBe('[1,3,5]');
+	});
+
+	it('serializes an empty input as the full week fallback', () => {
+		expect(serializeTemplateDays([])).toBe('[0,1,2,3,4,5,6]');
+	});
+});
+
+describe('getEntriesToDeleteForDays', () => {
+	it('returns ids of entries whose weekday is not in the allowed list', () => {
+		// 2026-03-02 is a Monday (day 1), 2026-03-07 is a Saturday (day 6)
+		const entries = [
+			{ id: 'entry_mon', date: '2026-03-02' },
+			{ id: 'entry_sat', date: '2026-03-07' }
+		];
+
+		// Only allow Monday (1)
+		const toDelete = getEntriesToDeleteForDays(entries, [1]);
+		expect(toDelete).toEqual(['entry_sat']);
+	});
+
+	it('returns an empty array when all entries fall on allowed days', () => {
+		const entries = [
+			{ id: 'entry_mon', date: '2026-03-02' },
+			{ id: 'entry_tue', date: '2026-03-03' }
+		];
+
+		const toDelete = getEntriesToDeleteForDays(entries, [1, 2]);
+		expect(toDelete).toHaveLength(0);
+	});
+
+	it('returns all entry ids when no days are allowed', () => {
+		const entries = [
+			{ id: 'entry_1', date: '2026-03-02' },
+			{ id: 'entry_2', date: '2026-03-03' }
+		];
+
+		const toDelete = getEntriesToDeleteForDays(entries, []);
+		expect(toDelete).toEqual(['entry_1', 'entry_2']);
+	});
+
+	it('returns an empty array for an empty entry list', () => {
+		expect(getEntriesToDeleteForDays([], [1, 2, 3])).toHaveLength(0);
+	});
+});
+
+describe('assertDateIsEditable', () => {
+	beforeEach(() => {
+		// Fix "today" to 2026-05-12 in Pacific time (UTC-7 during PDT)
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-05-12T12:00:00.000-07:00'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('does not throw for today', () => {
+		expect(() => assertDateIsEditable('2026-05-12')).not.toThrow();
+	});
+
+	it('does not throw for future dates', () => {
+		expect(() => assertDateIsEditable('2026-05-13')).not.toThrow();
+		expect(() => assertDateIsEditable('2027-01-01')).not.toThrow();
+	});
+
+	it('throws DailyAgendaMutationError for past dates', () => {
+		expect(() => assertDateIsEditable('2026-05-11')).toThrow(DailyAgendaMutationError);
+		expect(() => assertDateIsEditable('2026-01-01')).toThrow(DailyAgendaMutationError);
+	});
+
+	it('sets the error code to read_only', () => {
+		try {
+			assertDateIsEditable('2026-05-11');
+		} catch (e) {
+			expect(e).toBeInstanceOf(DailyAgendaMutationError);
+			if (e instanceof DailyAgendaMutationError) {
+				expect(e.code).toBe('read_only');
+			}
+		}
+	});
+});

--- a/src/lib/server/daily-agenda.ts
+++ b/src/lib/server/daily-agenda.ts
@@ -34,13 +34,13 @@ export class DailyAgendaMutationError extends Error {
 	}
 }
 
-function assertDateIsEditable(date: string): void {
+export function assertDateIsEditable(date: string): void {
 	if (date < getTodayString()) {
 		throw new DailyAgendaMutationError('Historical items are read only', 'read_only');
 	}
 }
 
-function calculateCompletionPercentage(entries: Array<{ completed: boolean }>): number {
+export function calculateCompletionPercentage(entries: Array<{ completed: boolean }>): number {
 	if (entries.length === 0) {
 		return 0;
 	}
@@ -49,7 +49,7 @@ function calculateCompletionPercentage(entries: Array<{ completed: boolean }>): 
 	return Math.round((completedCount / entries.length) * 100);
 }
 
-function buildDateRangeLabel(startDate: string, endDate: string): string {
+export function buildDateRangeLabel(startDate: string, endDate: string): string {
 	const start = parseLocalDateString(startDate);
 	const end = parseLocalDateString(endDate);
 
@@ -66,7 +66,7 @@ function buildDateRangeLabel(startDate: string, endDate: string): string {
 	return `${startLabel} - ${endLabel}`;
 }
 
-function normalizeTemplateDays(daysOfWeek: number[]): number[] {
+export function normalizeTemplateDays(daysOfWeek: number[]): number[] {
 	const normalizedDays = Array.from(new Set(daysOfWeek))
 		.filter((day) => Number.isInteger(day) && day >= 0 && day <= 6)
 		.sort((left, right) => left - right);
@@ -74,7 +74,7 @@ function normalizeTemplateDays(daysOfWeek: number[]): number[] {
 	return normalizedDays.length > 0 ? normalizedDays : [...EVERY_DAY_TEMPLATE_DAYS];
 }
 
-function parseTemplateDays(daysOfWeek: string): number[] {
+export function parseTemplateDays(daysOfWeek: string): number[] {
 	try {
 		const parsed = JSON.parse(daysOfWeek);
 		if (!Array.isArray(parsed)) {
@@ -88,11 +88,11 @@ function parseTemplateDays(daysOfWeek: string): number[] {
 	}
 }
 
-function serializeTemplateDays(daysOfWeek: number[]): string {
+export function serializeTemplateDays(daysOfWeek: number[]): string {
 	return JSON.stringify(normalizeTemplateDays(daysOfWeek));
 }
 
-function getEntriesToDeleteForDays(
+export function getEntriesToDeleteForDays(
 	entries: Array<{ id: string; date: string }>,
 	allowedDays: number[]
 ): string[] {

--- a/src/lib/server/email/scheduled-visit-reminder-utils.test.ts
+++ b/src/lib/server/email/scheduled-visit-reminder-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildScheduledVisitReminderEntityId,
+	buildScheduledVisitReminderSubject,
+	formatReminderDate,
+	getDateDaysAhead
+} from './scheduled-visit-reminder-utils';
+
+describe('getDateDaysAhead', () => {
+	it('returns the correct date when adding positive days', () => {
+		expect(getDateDaysAhead(new Date('2026-01-01'), 7)).toBe('2026-01-08');
+		expect(getDateDaysAhead(new Date('2026-03-25'), 10)).toBe('2026-04-04');
+	});
+
+	it('handles month-boundary rollover correctly', () => {
+		expect(getDateDaysAhead(new Date('2026-01-28'), 7)).toBe('2026-02-04');
+	});
+
+	it('handles year-boundary rollover correctly', () => {
+		expect(getDateDaysAhead(new Date('2025-12-28'), 7)).toBe('2026-01-04');
+	});
+
+	it('returns the same date when days is 0', () => {
+		expect(getDateDaysAhead(new Date('2026-06-15'), 0)).toBe('2026-06-15');
+	});
+});
+
+describe('formatReminderDate', () => {
+	it('formats a YYYY-MM-DD string as Month D, YYYY', () => {
+		expect(formatReminderDate('2026-03-15')).toBe('March 15, 2026');
+	});
+
+	it('formats single-digit days without zero padding', () => {
+		expect(formatReminderDate('2026-01-07')).toBe('January 7, 2026');
+	});
+
+	it('formats the last day of the year correctly', () => {
+		expect(formatReminderDate('2025-12-31')).toBe('December 31, 2025');
+	});
+});
+
+describe('buildScheduledVisitReminderEntityId', () => {
+	it('prefixes the visit id with the reminder namespace', () => {
+		expect(buildScheduledVisitReminderEntityId('visit_abc123')).toBe(
+			'scheduled_visit:visit_abc123'
+		);
+	});
+});
+
+describe('buildScheduledVisitReminderSubject', () => {
+	it('includes the person name in the subject line', () => {
+		const subject = buildScheduledVisitReminderSubject('Alice');
+		expect(subject).toContain('Alice');
+		expect(subject).toContain('one week');
+	});
+
+	it('includes the emoji marker in the subject', () => {
+		expect(buildScheduledVisitReminderSubject('Bob')).toContain('📅');
+	});
+});

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	addDaysToDateString,
+	formatDateLong,
+	formatDateMedium,
+	formatDateShort,
+	formatTime12Hour,
+	formatTimeFromTimestamp,
+	formatTimestampLong,
+	formatTimestampMedium,
+	formatTimestampShort,
+	getDateRange,
 	getDateUrgencyStatus,
 	getRollingDateRange,
+	getStartOfMonth,
+	getStartOfQuarter,
 	getStartOfWeek,
 	getTodayString,
 	getWeekDates,
@@ -72,5 +83,101 @@ describe('date urgency helpers', () => {
 	it('uses Pacific time when calculating today across a UTC midnight boundary', () => {
 		expect(getTodayString(new Date('2026-03-13T06:59:59.000Z'))).toBe('2026-03-12');
 		expect(getTodayString(new Date('2026-03-13T07:00:00.000Z'))).toBe('2026-03-13');
+	});
+
+	it('handles leap year day correctly', () => {
+		expect(addDaysToDateString('2024-02-28', 1)).toBe('2024-02-29');
+		expect(addDaysToDateString('2024-02-29', 1)).toBe('2024-03-01');
+	});
+
+	it('handles year-boundary rollover', () => {
+		expect(addDaysToDateString('2025-12-31', 1)).toBe('2026-01-01');
+		expect(addDaysToDateString('2026-01-01', -1)).toBe('2025-12-31');
+	});
+});
+
+describe('date range helpers', () => {
+	it('returns an inclusive range of dates between two dates', () => {
+		expect(getDateRange('2026-03-01', '2026-03-04')).toEqual([
+			'2026-03-01',
+			'2026-03-02',
+			'2026-03-03',
+			'2026-03-04'
+		]);
+	});
+
+	it('returns a single-element array when start equals end', () => {
+		expect(getDateRange('2026-05-10', '2026-05-10')).toEqual(['2026-05-10']);
+	});
+
+	it('returns the start of the month for any day in that month', () => {
+		expect(getStartOfMonth('2026-03-15')).toBe('2026-03-01');
+		expect(getStartOfMonth('2026-01-01')).toBe('2026-01-01');
+	});
+
+	it('returns the Monday start of the week for Sunday', () => {
+		expect(getStartOfWeek('2026-03-15')).toBe('2026-03-09');
+	});
+
+	it('returns the quarter start for each quarter', () => {
+		expect(getStartOfQuarter('2026-01-15')).toBe('2026-01-01');
+		expect(getStartOfQuarter('2026-04-30')).toBe('2026-04-01');
+		expect(getStartOfQuarter('2026-07-01')).toBe('2026-07-01');
+		expect(getStartOfQuarter('2026-10-31')).toBe('2026-10-01');
+	});
+});
+
+describe('date display formatters', () => {
+	it('formats a date in long form with weekday', () => {
+		const formatted = formatDateLong('2026-03-09');
+		expect(formatted).toContain('Monday');
+		expect(formatted).toContain('March');
+		expect(formatted).toContain('2026');
+	});
+
+	it('formats a date in medium form with abbreviated weekday', () => {
+		const formatted = formatDateMedium('2026-03-09');
+		expect(formatted).toContain('Mon');
+		expect(formatted).toContain('Mar');
+		expect(formatted).toContain('9');
+	});
+
+	it('formats a date in short form without a weekday', () => {
+		const formatted = formatDateShort('2026-03-09');
+		expect(formatted).toContain('Mar');
+		expect(formatted).toContain('2026');
+		expect(formatted).not.toContain('Mon');
+	});
+});
+
+describe('timestamp formatters', () => {
+	it('formats a UTC timestamp in long form with time', () => {
+		const formatted = formatTimestampLong('2026-03-09T20:30:00.000Z');
+		expect(formatted).toContain('Mar');
+		expect(formatted).toContain('2026');
+	});
+
+	it('formats a UTC timestamp in medium form with abbreviated weekday', () => {
+		const formatted = formatTimestampMedium('2026-03-09T20:30:00.000Z');
+		expect(formatted).toContain('Mar');
+		expect(formatted).toContain('9');
+	});
+
+	it('formats a UTC timestamp in short form with date only', () => {
+		const formatted = formatTimestampShort('2026-03-09T20:30:00.000Z');
+		expect(formatted).toContain('Mar');
+		expect(formatted).toContain('2026');
+	});
+
+	it('extracts just the time portion from a timestamp', () => {
+		const formatted = formatTimeFromTimestamp('2026-03-09T14:30:00.000Z');
+		expect(formatted).toContain('30');
+	});
+
+	it('converts 24-hour time to 12-hour AM/PM format', () => {
+		expect(formatTime12Hour('14:30')).toContain('2:30');
+		expect(formatTime12Hour('14:30')).toContain('PM');
+		expect(formatTime12Hour('09:05')).toContain('9:05');
+		expect(formatTime12Hour('09:05')).toContain('AM');
 	});
 });

--- a/src/lib/utils/mood.test.ts
+++ b/src/lib/utils/mood.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	getMoodChartColor,
+	getMoodScore,
+	getMoodScoreLabel,
+	isMoodValue,
+	normalizeOptionalMoodText,
+	resolveMoodLabel
+} from './mood';
+
+describe('isMoodValue', () => {
+	it('returns true for all valid mood values', () => {
+		const validMoods = [
+			'sad',
+			'anxious',
+			'overwhelmed',
+			'tired',
+			'calm',
+			'focused',
+			'content',
+			'happy',
+			'custom'
+		];
+
+		for (const mood of validMoods) {
+			expect(isMoodValue(mood)).toBe(true);
+		}
+	});
+
+	it('returns false for invalid mood values', () => {
+		expect(isMoodValue('angry')).toBe(false);
+		expect(isMoodValue('')).toBe(false);
+		expect(isMoodValue('HAPPY')).toBe(false);
+		expect(isMoodValue('great')).toBe(false);
+	});
+});
+
+describe('getMoodScore', () => {
+	it('returns the correct score for each mood', () => {
+		expect(getMoodScore('sad')).toBe(1);
+		expect(getMoodScore('anxious')).toBe(2);
+		expect(getMoodScore('calm')).toBe(5);
+		expect(getMoodScore('focused')).toBe(6);
+		expect(getMoodScore('content')).toBe(7);
+		expect(getMoodScore('happy')).toBe(8);
+	});
+
+	it('returns the default score of 4 for unknown moods', () => {
+		expect(getMoodScore('unknown')).toBe(4);
+		expect(getMoodScore('')).toBe(4);
+	});
+});
+
+describe('getMoodChartColor', () => {
+	it('returns the correct chart color for known moods', () => {
+		expect(getMoodChartColor('sad')).toBe('var(--chart-5)');
+		expect(getMoodChartColor('content')).toBe('var(--color-green)');
+	});
+
+	it('returns the fallback chart color for unknown moods', () => {
+		expect(getMoodChartColor('unknown')).toBe('var(--chart-3)');
+		expect(getMoodChartColor('')).toBe('var(--chart-3)');
+	});
+});
+
+describe('resolveMoodLabel', () => {
+	it('returns the standard label for non-custom moods', () => {
+		expect(resolveMoodLabel('happy', null)).toBe('Happy');
+		expect(resolveMoodLabel('calm', undefined)).toBe('Calm');
+		expect(resolveMoodLabel('sad', 'ignored custom')).toBe('Sad');
+	});
+
+	it('returns the custom mood label when mood is custom', () => {
+		expect(resolveMoodLabel('custom', 'Grateful')).toBe('Grateful');
+	});
+
+	it('trims whitespace from custom mood labels', () => {
+		expect(resolveMoodLabel('custom', '  Grateful  ')).toBe('Grateful');
+	});
+
+	it('falls back to Custom when the custom label is empty or whitespace', () => {
+		expect(resolveMoodLabel('custom', '')).toBe('Custom');
+		expect(resolveMoodLabel('custom', '   ')).toBe('Custom');
+		expect(resolveMoodLabel('custom', null)).toBe('Custom');
+		expect(resolveMoodLabel('custom', undefined)).toBe('Custom');
+	});
+
+	it('returns the raw mood string for completely unknown moods', () => {
+		expect(resolveMoodLabel('mystery', null)).toBe('mystery');
+	});
+});
+
+describe('getMoodScoreLabel', () => {
+	it('maps score 1 to Sad and score 8 to Happy', () => {
+		expect(getMoodScoreLabel(1)).toBe('Sad');
+		expect(getMoodScoreLabel(8)).toBe('Happy');
+	});
+
+	it('clamps scores below 1 to 1', () => {
+		expect(getMoodScoreLabel(0)).toBe('Sad');
+		expect(getMoodScoreLabel(-5)).toBe('Sad');
+	});
+
+	it('clamps scores above 8 to 8', () => {
+		expect(getMoodScoreLabel(9)).toBe('Happy');
+		expect(getMoodScoreLabel(100)).toBe('Happy');
+	});
+
+	it('rounds fractional scores to the nearest integer', () => {
+		expect(getMoodScoreLabel(1.4)).toBe('Sad');
+		expect(getMoodScoreLabel(1.5)).toBe('Anxious');
+	});
+});
+
+describe('normalizeOptionalMoodText', () => {
+	it('returns the trimmed text for non-empty strings', () => {
+		expect(normalizeOptionalMoodText('  Grateful  ')).toBe('Grateful');
+		expect(normalizeOptionalMoodText('content')).toBe('content');
+	});
+
+	it('returns null for empty or whitespace strings', () => {
+		expect(normalizeOptionalMoodText('')).toBeNull();
+		expect(normalizeOptionalMoodText('   ')).toBeNull();
+	});
+
+	it('returns null for null and undefined', () => {
+		expect(normalizeOptionalMoodText(null)).toBeNull();
+		expect(normalizeOptionalMoodText(undefined)).toBeNull();
+	});
+});

--- a/src/lib/utils/visit-status.test.ts
+++ b/src/lib/utils/visit-status.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { getTodayString } from '$lib/utils/date';
+
 import {
 	calculatePersonVisitStatus,
 	calculateVisitStatus,
@@ -9,8 +11,8 @@ import {
 
 function dateDaysAgo(daysAgo: number): string {
 	const date = new Date();
-	date.setUTCDate(date.getUTCDate() - daysAgo);
-	return date.toISOString().split('T')[0];
+	date.setDate(date.getDate() - daysAgo);
+	return getTodayString(date);
 }
 
 describe('visit status exemptions', () => {
@@ -44,7 +46,7 @@ describe('visit status exemptions', () => {
 
 	it('marks person as scheduled when latest follow-up is today or later', () => {
 		const redVisitDate = dateDaysAgo(400);
-		const today = new Date().toISOString().split('T')[0];
+		const today = getTodayString();
 
 		const result = calculatePersonVisitStatus(redVisitDate, false, today, today);
 
@@ -55,7 +57,7 @@ describe('visit status exemptions', () => {
 
 	it('gives scheduled precedence over exempt', () => {
 		const redVisitDate = dateDaysAgo(400);
-		const today = new Date().toISOString().split('T')[0];
+		const today = getTodayString();
 
 		const result = calculatePersonVisitStatus(redVisitDate, true, today, today);
 
@@ -65,7 +67,7 @@ describe('visit status exemptions', () => {
 	it('returns normal status when latest follow-up is in the past', () => {
 		const redVisitDate = dateDaysAgo(400);
 		const yesterday = dateDaysAgo(1);
-		const today = new Date().toISOString().split('T')[0];
+		const today = getTodayString();
 
 		const result = calculatePersonVisitStatus(redVisitDate, false, yesterday, today);
 

--- a/src/lib/utils/visit-status.test.ts
+++ b/src/lib/utils/visit-status.test.ts
@@ -78,3 +78,43 @@ describe('visit status exemptions', () => {
 		expect(getStatusPriority('scheduled')).toBeLessThan(getStatusPriority('none'));
 	});
 });
+
+describe('visit status boundary thresholds', () => {
+	it('returns green well within the 9-month window', () => {
+		const date = dateDaysAgo(180);
+		const result = calculateVisitStatus(date);
+		expect(result.status).toBe('green');
+		expect(result.daysUntilStatusChange).toBeGreaterThan(0);
+	});
+
+	it('returns yellow in the 9-12 month range', () => {
+		const date = dateDaysAgo(300);
+		const result = calculateVisitStatus(date);
+		expect(result.status).toBe('yellow');
+		expect(result.daysUntilStatusChange).toBeGreaterThan(0);
+	});
+
+	it('returns yellow at 274 days (first reliable yellow day)', () => {
+		const date = dateDaysAgo(274);
+		expect(calculateVisitStatus(date).status).toBe('yellow');
+	});
+
+	it('returns red well beyond the 12-month mark', () => {
+		const date = dateDaysAgo(400);
+		const result = calculateVisitStatus(date);
+		expect(result.status).toBe('red');
+		expect(result.daysUntilStatusChange).toBeNull();
+	});
+
+	it('returns red at 365 days', () => {
+		const date = dateDaysAgo(365);
+		expect(calculateVisitStatus(date).status).toBe('red');
+	});
+
+	it('returns none when there is no visit date', () => {
+		const result = calculateVisitStatus(null);
+		expect(result.status).toBe('none');
+		expect(result.daysSinceLastVisit).toBeNull();
+		expect(result.daysUntilStatusChange).toBeNull();
+	});
+});

--- a/src/lib/utils/workout.test.ts
+++ b/src/lib/utils/workout.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	getWorkoutBadgeClass,
+	getWorkoutBorderClass,
+	getWorkoutChartColor,
+	getWorkoutEmoji,
+	getWorkoutLabel,
+	getWorkoutNotificationTag
+} from './workout';
+
+describe('getWorkoutLabel', () => {
+	it('returns the correct label for each workout type', () => {
+		expect(getWorkoutLabel('strength')).toBe('Strength');
+		expect(getWorkoutLabel('cardio')).toBe('Cardio');
+		expect(getWorkoutLabel('hiit')).toBe('HIIT');
+		expect(getWorkoutLabel('walk')).toBe('Walk');
+		expect(getWorkoutLabel('stretch')).toBe('Stretch');
+		expect(getWorkoutLabel('other')).toBe('Other');
+	});
+
+	it('returns the Other fallback for unknown types', () => {
+		expect(getWorkoutLabel('unknown')).toBe('Other');
+		expect(getWorkoutLabel('')).toBe('Other');
+	});
+});
+
+describe('getWorkoutBorderClass', () => {
+	it('returns the correct border class for known types', () => {
+		expect(getWorkoutBorderClass('strength')).toBe('border-l-orange-500');
+		expect(getWorkoutBorderClass('cardio')).toBe('border-l-blue-500');
+		expect(getWorkoutBorderClass('hiit')).toBe('border-l-red-500');
+		expect(getWorkoutBorderClass('walk')).toBe('border-l-green-500');
+		expect(getWorkoutBorderClass('stretch')).toBe('border-l-purple-500');
+		expect(getWorkoutBorderClass('other')).toBe('border-l-gray-400');
+	});
+
+	it('falls back to gray border for unknown types', () => {
+		expect(getWorkoutBorderClass('unknown')).toBe('border-l-gray-400');
+	});
+});
+
+describe('getWorkoutBadgeClass', () => {
+	it('returns badge class for each known workout type', () => {
+		expect(getWorkoutBadgeClass('strength')).toContain('orange');
+		expect(getWorkoutBadgeClass('cardio')).toContain('blue');
+		expect(getWorkoutBadgeClass('hiit')).toContain('red');
+		expect(getWorkoutBadgeClass('walk')).toContain('green');
+		expect(getWorkoutBadgeClass('stretch')).toContain('purple');
+		expect(getWorkoutBadgeClass('other')).toContain('gray');
+	});
+
+	it('falls back to gray badge for unknown types', () => {
+		expect(getWorkoutBadgeClass('yoga')).toContain('gray');
+	});
+});
+
+describe('getWorkoutChartColor', () => {
+	it('returns CSS variable chart colors for known types', () => {
+		expect(getWorkoutChartColor('strength')).toBe('var(--chart-1)');
+		expect(getWorkoutChartColor('cardio')).toBe('var(--chart-2)');
+		expect(getWorkoutChartColor('hiit')).toBe('var(--chart-5)');
+		expect(getWorkoutChartColor('walk')).toBe('var(--chart-4)');
+	});
+
+	it('falls back to chart-3 for unknown types', () => {
+		expect(getWorkoutChartColor('unknown')).toBe('var(--chart-3)');
+	});
+});
+
+describe('getWorkoutEmoji', () => {
+	it('returns the correct emoji for each workout type', () => {
+		expect(getWorkoutEmoji('strength')).toBe('💪');
+		expect(getWorkoutEmoji('cardio')).toBe('🏃');
+		expect(getWorkoutEmoji('hiit')).toBe('🔥');
+		expect(getWorkoutEmoji('walk')).toBe('🚶');
+		expect(getWorkoutEmoji('stretch')).toBe('🤸');
+		expect(getWorkoutEmoji('other')).toBe('🏋️');
+	});
+
+	it('falls back to the weightlifter emoji for unknown types', () => {
+		expect(getWorkoutEmoji('dancing')).toBe('🏋️');
+	});
+});
+
+describe('getWorkoutNotificationTag', () => {
+	it('returns the correct notification tag for each workout type', () => {
+		expect(getWorkoutNotificationTag('strength')).toBe('muscle');
+		expect(getWorkoutNotificationTag('cardio')).toBe('runner');
+		expect(getWorkoutNotificationTag('hiit')).toBe('fire');
+		expect(getWorkoutNotificationTag('walk')).toBe('walking');
+		expect(getWorkoutNotificationTag('stretch')).toBe('person_doing_cartwheel');
+		expect(getWorkoutNotificationTag('other')).toBe('weight_lifter');
+	});
+
+	it('falls back to weight_lifter for unknown types', () => {
+		expect(getWorkoutNotificationTag('cycling')).toBe('weight_lifter');
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,13 @@ export default defineConfig({
 				'src/app.ts',
 				'src/service-worker.ts'
 			],
-			reporter: ['text', 'lcov', 'html', 'json-summary', 'json']
+			reporter: ['text', 'lcov', 'html', 'json-summary', 'json'],
+			thresholds: {
+				statements: 30,
+				branches: 30,
+				functions: 30,
+				lines: 30
+			}
 		},
 		reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : ['default']
 	}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for all schema validation logic in the application, covering authentication, daily agenda, fitness, journal, meditation, mood, and task-related schemas. These tests ensure that each schema correctly accepts valid input, rejects invalid input, and handles edge cases, significantly improving confidence in data validation throughout the codebase.

**Authentication schema tests:**  
- Adds tests for `registerSchema`, `loginSchema`, `forgotPasswordSchema`, `resetPasswordSchema`, `updateProfileSchema`, and `changePasswordSchema`, verifying field requirements, password policies, email validation, and proper error reporting for mismatched or invalid input.

**Fitness schema tests:**  
- Introduces tests for schemas such as `logWeightSchema`, `logWorkoutSchema`, `logMealSchema`, and related update and target-setting schemas, checking for correct value coercion, type acceptance, validation of required fields, and rejection of invalid data (e.g., negative weights, unknown workout types).

**Meditation schema tests:**  
- Adds tests for `createRoutineSchema`, `updateRoutineSchema`, `scheduleSchema`, `completeSessionSchema`, `editSessionSchema`, and `routineFilterSchema`, ensuring correct handling of required fields, URL and time validation, mood tag constraints, and payload acceptance/rejection.

**Journal and mood schema tests:**  
- Implements tests for `journalEntrySchema`, `journalFilterSchema`, `moodLogSchema`, and `moodPeriodSchema`, verifying date formats, field requirements, default values, mood validation, and string length limits. [[1]](diffhunk://#diff-8eaac963abf4e7425aa8d69a86fdfb8adacf55bb2e2de51e5d52428621c9f76eR1-R63) [[2]](diffhunk://#diff-79d241c6812cb7377d3caf553d462fccc7f0a34a7af3aea1d1e29b61856b61d1R1-R86)

**Daily agenda and task schema tests:**  
- Expands tests for daily agenda schemas to handle boolean-like values and day-of-week constraints, and for tasks to check priority bounds, due date formats, and title length restrictions. [[1]](diffhunk://#diff-d8ed796e035ce5b990cb33cf331df296048861e6b01047344587763c2e7a8166R106-R143) [[2]](diffhunk://#diff-1f2f3005d454d43b373c52f97ae8ff3e5fdabf751d70b1429c3666ee37082b4cR141-R167)