### PR TITLE
Add agenda item stats calculation and tests

### DIFF
--- a/src/lib/components/dashboard/AgendaItemScorecard.svelte
+++ b/src/lib/components/dashboard/AgendaItemScorecard.svelte
@@ -4,7 +4,7 @@
 		completionPct: number;
 		prevCompletionPct: number;
 		dowCompletionPct: number[]; // index 0=Mon … 6=Sun, -1 = not scheduled that day
-		totalDays: number;
+		last4Days: number;
 	};
 
 	let { items }: { items: AgendaItemStat[] } = $props();

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -69,7 +69,7 @@ type ItemBucket = {
 	titleDate: string;
 	last4: { total: number; completed: number };
 	prev4: { total: number; completed: number };
-	dow: { total: number[]; completed: number[] };
+	dowLast4: { total: number[]; completed: number[] };
 };
 
 const STATUS_KEY_MAP: Record<string, VisitHealthBucket> = {
@@ -179,6 +179,8 @@ function buildDateRanges(today: string): DashboardDateRanges {
 		tasksCompletionRangeEndIso: `${addDaysToDateString(endOfThisWeekDate, 1)}T00:00:00.000Z`
 	};
 }
+
+export const _buildDateRanges = buildDateRanges;
 
 // ── Database queries ───────────────────────────────────────────────────────────
 async function runDashboardQueries(
@@ -387,6 +389,17 @@ async function runDashboardQueries(
 
 type QueryData = Awaited<ReturnType<typeof runDashboardQueries>>;
 
+type AgendaItemStat = {
+	title: string;
+	completionPct: number;
+	prevCompletionPct: number;
+	dowCompletionPct: number[];
+	totalDays: number;
+};
+
+type AgendaRangeWindow = 'last4' | 'prev4';
+type AgendaTrendEntry = QueryData['agendaEntriesForTrend'][number];
+
 // ── Post-processing helpers ────────────────────────────────────────────────────
 function buildCountByDateMap(rows: { date: string; count: number }[]): Map<string, number> {
 	return new Map(rows.map((r) => [r.date, Number(r.count || 0)]));
@@ -521,65 +534,109 @@ function buildActivityFeed(
 		.slice(0, 10);
 }
 
+function getAgendaRangeWindow(
+	date: string,
+	ranges: Pick<DashboardDateRanges, 'agenda8WeeksStart' | 'last4WeeksStart' | 'endOfThisWeekDate'>
+): AgendaRangeWindow | null {
+	if (date >= ranges.last4WeeksStart && date < ranges.endOfThisWeekDate) {
+		return 'last4';
+	}
+
+	if (date >= ranges.agenda8WeeksStart && date < ranges.last4WeeksStart) {
+		return 'prev4';
+	}
+
+	return null;
+}
+
+function createItemBucket(entry: AgendaTrendEntry): ItemBucket {
+	return {
+		title: entry.title,
+		titleDate: entry.date,
+		last4: { total: 0, completed: 0 },
+		prev4: { total: 0, completed: 0 },
+		dowLast4: {
+			total: Array.from({ length: 7 }, () => 0),
+			completed: Array.from({ length: 7 }, () => 0)
+		}
+	};
+}
+
+function getOrCreateItemBucket(
+	itemBuckets: Map<string, ItemBucket>,
+	groupKey: string,
+	entry: AgendaTrendEntry
+): ItemBucket {
+	let bucket = itemBuckets.get(groupKey);
+	if (!bucket) {
+		bucket = createItemBucket(entry);
+		itemBuckets.set(groupKey, bucket);
+	}
+	return bucket;
+}
+
+function addEntryToBucket(
+	bucket: ItemBucket,
+	entry: AgendaTrendEntry,
+	window: AgendaRangeWindow
+): void {
+	if (entry.date > bucket.titleDate) {
+		bucket.title = entry.title;
+		bucket.titleDate = entry.date;
+	}
+
+	const period = window === 'last4' ? bucket.last4 : bucket.prev4;
+	period.total++;
+	if (entry.completed) period.completed++;
+
+	if (window === 'last4') {
+		const dowIndex = getISODayOfWeek(entry.date);
+		bucket.dowLast4.total[dowIndex]++;
+		if (entry.completed) bucket.dowLast4.completed[dowIndex]++;
+	}
+}
+
+function toPct(completed: number, total: number): number {
+	return total > 0 ? Math.round((completed / total) * 100) : 0;
+}
+
+function toDowCompletionPct(bucket: ItemBucket): number[] {
+	return bucket.dowLast4.total.map((tot, i) =>
+		tot > 0 ? Math.round((bucket.dowLast4.completed[i] / tot) * 100) : -1
+	);
+}
+
+function toAgendaItemStat(bucket: ItemBucket): AgendaItemStat {
+	return {
+		title: bucket.title,
+		completionPct: toPct(bucket.last4.completed, bucket.last4.total),
+		prevCompletionPct: toPct(bucket.prev4.completed, bucket.prev4.total),
+		dowCompletionPct: toDowCompletionPct(bucket),
+		totalDays: bucket.last4.total
+	};
+}
+
 function buildAgendaItemStats(
 	entries: QueryData['agendaEntriesForTrend'],
 	ranges: DashboardDateRanges
-): {
-	title: string;
-	completionPct: number;
-	prevCompletionPct: number;
-	dowCompletionPct: number[];
-	totalDays: number;
-}[] {
-	const { agenda8WeeksStart, endOfThisWeekDate, last4WeeksStart } = ranges;
+): AgendaItemStat[] {
 	const itemBuckets = new Map<string, ItemBucket>();
 
 	for (const entry of entries) {
-		const isLast4 = entry.date >= last4WeeksStart && entry.date < endOfThisWeekDate;
-		const isPrev4 = entry.date >= agenda8WeeksStart && entry.date < last4WeeksStart;
-		if (!isLast4 && !isPrev4) continue;
-
+		const window = getAgendaRangeWindow(entry.date, ranges);
+		if (!window) continue;
 		const groupKey = entry.templateGroupId ?? entry.title;
-		const dowIndex = getISODayOfWeek(entry.date);
-		let bucket = itemBuckets.get(groupKey);
-		if (!bucket) {
-			bucket = {
-				title: entry.title,
-				titleDate: entry.date,
-				last4: { total: 0, completed: 0 },
-				prev4: { total: 0, completed: 0 },
-				dow: {
-					total: Array.from<number>({ length: 7 }),
-					completed: Array.from<number>({ length: 7 })
-				}
-			};
-			itemBuckets.set(groupKey, bucket);
-		}
-		if (entry.date > bucket.titleDate) {
-			bucket.title = entry.title;
-			bucket.titleDate = entry.date;
-		}
-		const period = isLast4 ? bucket.last4 : bucket.prev4;
-		period.total++;
-		if (entry.completed) period.completed++;
-		bucket.dow.total[dowIndex]++;
-		if (entry.completed) bucket.dow.completed[dowIndex]++;
+		const bucket = getOrCreateItemBucket(itemBuckets, groupKey, entry);
+		addEntryToBucket(bucket, entry, window);
 	}
 
 	return Array.from(itemBuckets.values())
 		.filter((b) => b.last4.total + b.prev4.total >= 7)
-		.map((b) => ({
-			title: b.title,
-			completionPct: b.last4.total > 0 ? Math.round((b.last4.completed / b.last4.total) * 100) : 0,
-			prevCompletionPct:
-				b.prev4.total > 0 ? Math.round((b.prev4.completed / b.prev4.total) * 100) : 0,
-			dowCompletionPct: b.dow.total.map((tot, i) =>
-				tot > 0 ? Math.round((b.dow.completed[i] / tot) * 100) : -1
-			),
-			totalDays: b.last4.total + b.prev4.total
-		}))
+		.map(toAgendaItemStat)
 		.sort((a, b) => a.completionPct - b.completionPct);
 }
+
+export const _buildAgendaItemStats = buildAgendaItemStats;
 
 function buildTodayAgendaSummary(entries: QueryData['agendaEntriesForTrend'], today: string) {
 	const todayEntries = entries

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -394,7 +394,7 @@ type AgendaItemStat = {
 	completionPct: number;
 	prevCompletionPct: number;
 	dowCompletionPct: number[];
-	totalDays: number;
+	last4Days: number;
 };
 
 type AgendaRangeWindow = 'last4' | 'prev4';
@@ -612,7 +612,7 @@ function toAgendaItemStat(bucket: ItemBucket): AgendaItemStat {
 		completionPct: toPct(bucket.last4.completed, bucket.last4.total),
 		prevCompletionPct: toPct(bucket.prev4.completed, bucket.prev4.total),
 		dowCompletionPct: toDowCompletionPct(bucket),
-		totalDays: bucket.last4.total
+		last4Days: bucket.last4.total
 	};
 }
 
@@ -686,7 +686,7 @@ function emptyDashboardReturn() {
 			completionPct: number;
 			prevCompletionPct: number;
 			dowCompletionPct: number[];
-			totalDays: number;
+			last4Days: number;
 		}[],
 		daysSinceLastWorkout: null as number | null,
 		todayAgendaSummary: {

--- a/src/routes/(app)/dashboard/agenda-item-stats.test.ts
+++ b/src/routes/(app)/dashboard/agenda-item-stats.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { _buildAgendaItemStats, _buildDateRanges } from './+page.server';
+
+type AgendaEntry = {
+	id: string;
+	date: string;
+	completed: boolean;
+	title: string;
+	templateGroupId: string | null;
+	sortOrder: number;
+};
+
+function createEntry(input: Partial<AgendaEntry> & Pick<AgendaEntry, 'id' | 'date'>): AgendaEntry {
+	return {
+		id: input.id,
+		date: input.date,
+		completed: input.completed ?? false,
+		title: input.title ?? 'Exercise / Walk',
+		templateGroupId: input.templateGroupId ?? 'group-exercise',
+		sortOrder: input.sortOrder ?? 0
+	};
+}
+
+describe('buildAgendaItemStats', () => {
+	it('computes DOW percentages from real counts (guards against NaN/-1 regression)', () => {
+		const ranges = _buildDateRanges('2026-05-26');
+		const entries: AgendaEntry[] = [
+			createEntry({ id: 'last4-mon-1', date: '2026-05-04', completed: true }),
+			createEntry({ id: 'last4-mon-2', date: '2026-05-11', completed: false }),
+			createEntry({ id: 'last4-tue-1', date: '2026-05-05', completed: true }),
+			createEntry({ id: 'prev4-1', date: '2026-04-07', completed: true }),
+			createEntry({ id: 'prev4-2', date: '2026-04-08', completed: false }),
+			createEntry({ id: 'prev4-3', date: '2026-04-09', completed: false }),
+			createEntry({ id: 'prev4-4', date: '2026-04-10', completed: false }),
+			createEntry({ id: 'prev4-5', date: '2026-04-11', completed: false })
+		];
+
+		const stats = _buildAgendaItemStats(entries, ranges);
+
+		expect(stats).toHaveLength(1);
+		expect(stats[0]?.completionPct).toBe(67);
+		expect(stats[0]?.dowCompletionPct[0]).toBe(50); // Monday: 1/2
+		expect(stats[0]?.dowCompletionPct[1]).toBe(100); // Tuesday: 1/1
+	});
+
+	it('uses only last 4 weeks for DOW dots (prev 4 should not affect dot colors/titles)', () => {
+		const ranges = _buildDateRanges('2026-05-26');
+		const entries: AgendaEntry[] = [
+			createEntry({ id: 'last4-mon-1', date: '2026-05-12', completed: false }),
+			createEntry({ id: 'prev4-fri-1', date: '2026-04-10', completed: true }),
+			createEntry({ id: 'prev4-fri-2', date: '2026-04-17', completed: true }),
+			createEntry({ id: 'prev4-fri-3', date: '2026-04-24', completed: true }),
+			createEntry({ id: 'prev4-thu-1', date: '2026-04-09', completed: false }),
+			createEntry({ id: 'prev4-wed-1', date: '2026-04-08', completed: false }),
+			createEntry({ id: 'prev4-tue-1', date: '2026-04-07', completed: false })
+		];
+
+		const stats = _buildAgendaItemStats(entries, ranges);
+
+		expect(stats).toHaveLength(1);
+		expect(stats[0]?.dowCompletionPct[4]).toBe(-1); // Friday exists only in prev4 window
+		expect(stats[0]?.completionPct).toBe(0);
+		expect(stats[0]?.prevCompletionPct).toBe(50);
+	});
+});


### PR DESCRIPTION
This pull request refactors and enhances the logic for computing agenda item statistics in the dashboard, focusing on improved clarity, maintainability, and correctness of day-of-week (DOW) completion percentages. It introduces new helper functions, updates type definitions, and adds comprehensive tests to prevent regressions.

**Refactoring and logic improvements:**

* Refactored the `buildAgendaItemStats` function in `+page.server.ts` by breaking it into smaller, focused helper functions (`getAgendaRangeWindow`, `createItemBucket`, `getOrCreateItemBucket`, `addEntryToBucket`, `toPct`, `toDowCompletionPct`, `toAgendaItemStat`) for better readability and maintainability. Also, changed DOW tracking to only consider the last 4 weeks, ensuring accurate DOW completion percentages.
* Updated the `ItemBucket` type to rename the `dow` property to `dowLast4`, clarifying that DOW stats are only for the last 4 weeks.

**Testing and exports:**

* Added a new test file `agenda-item-stats.test.ts` with tests that verify correct DOW percentage calculations and ensure that only the last 4 weeks affect DOW stats, guarding against regressions.
* Exported internal helpers (`_buildAgendaItemStats` and `_buildDateRanges`) for testing purposes. [[1]](diffhunk://#diff-ef8a16b1b4477cd34c327842dbdba00cc381aa504ed88eba77d0e369f799477eR183-R184) [[2]](diffhunk://#diff-ef8a16b1b4477cd34c327842dbdba00cc381aa504ed88eba77d0e369f799477eL524-R640)

**Type additions:**

* Introduced new types (`AgendaItemStat`, `AgendaRangeWindow`, `AgendaTrendEntry`) to clarify function signatures and data flow.Implement calculations for agenda item statistics, including completion percentages and trends over specified time windows. Add corresponding tests to ensure accuracy and guard against regressions.