### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"layerchart": "^2.0.0-next.51",
 				"lefthook": "^2.1.9",
 				"lint-staged": "^17.0.7",
-				"oxfmt": "^0.53.0",
+				"oxfmt": "^0.54.0",
 				"oxlint": "^1.67.0",
 				"oxlint-tsgolint": "^0.23.0",
 				"svelte": "^5.55.1",
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@better-auth/core": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.11.tgz",
-			"integrity": "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.15.tgz",
+			"integrity": "sha512-gPgeEn+2t2cohSKj1CJFCJLo4jNqvtvhKP/y6Uwuurg4ReEf2Y9PUCYffvbp7DDc+GevWTuD0Cv9x0+e83+HpA==",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.39.0",
@@ -168,13 +168,13 @@
 				"zod": "^4.3.6"
 			},
 			"peerDependencies": {
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/utils": "0.4.1",
 				"@better-fetch/fetch": "1.1.21",
 				"@cloudflare/workers-types": ">=4",
 				"@opentelemetry/api": "^1.9.0",
 				"better-call": "1.3.5",
 				"jose": "^6.1.0",
-				"kysely": "^0.28.5",
+				"kysely": "^0.28.5 || ^0.29.0",
 				"nanostores": "^1.0.1"
 			},
 			"peerDependenciesMeta": {
@@ -187,13 +187,13 @@
 			}
 		},
 		"node_modules/@better-auth/drizzle-adapter": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.11.tgz",
-			"integrity": "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.15.tgz",
+			"integrity": "sha512-+ho2RozN6cZmCN+6XkZd/ec5iolVlefgInQ7znJ18qRPbgllHxdyu9tGrgKZyEsXSCyqAa6wi5Yb4hd3WZmTNQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1",
 				"drizzle-orm": "^0.45.2"
 			},
 			"peerDependenciesMeta": {
@@ -203,14 +203,14 @@
 			}
 		},
 		"node_modules/@better-auth/kysely-adapter": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.11.tgz",
-			"integrity": "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.15.tgz",
+			"integrity": "sha512-E29Sugm+DWRK4oQNBPrjPA4kBYiKy2bBtX1arIlkuyAB9A1BEb4Xn+8t7wlNIF5eFcxpkFZ3F80ceSpWDSYU0Q==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0",
-				"kysely": "^0.28.17"
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1",
+				"kysely": "^0.28.17 || ^0.29.0"
 			},
 			"peerDependenciesMeta": {
 				"kysely": {
@@ -219,23 +219,23 @@
 			}
 		},
 		"node_modules/@better-auth/memory-adapter": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.11.tgz",
-			"integrity": "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.15.tgz",
+			"integrity": "sha512-BRE5Ft0Tn5thOPjCmyXHge7kOI/paLybaKDU+Hzg24DZMU6JvWooYWzvf52r1viDbxq5tz0G97iyaH4bouDyug==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0"
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1"
 			}
 		},
 		"node_modules/@better-auth/mongo-adapter": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.11.tgz",
-			"integrity": "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.15.tgz",
+			"integrity": "sha512-r0X9AtFhwDeOU1KMP9kZ5NeV0O3TSFzn8+uidaH+aicy2e1dNUsd9nPYrozEloSxdA2ZOnv5gD4jzH7HPeKkUQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1",
 				"mongodb": "^6.0.0 || ^7.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -245,13 +245,13 @@
 			}
 		},
 		"node_modules/@better-auth/prisma-adapter": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.11.tgz",
-			"integrity": "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.15.tgz",
+			"integrity": "sha512-pUOlIUnpMu2l8C2ytgu46+OoOr3LZ+aLpJMFRGIPdnWl1BF2co2YaoZPT3+ZBu1Lzm0FrBN1ZRCAzZbkFoeIAQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1",
 				"@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
 				"prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
 			},
@@ -265,20 +265,20 @@
 			}
 		},
 		"node_modules/@better-auth/telemetry": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.11.tgz",
-			"integrity": "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.15.tgz",
+			"integrity": "sha512-eoFlUPVrVXLML9saHD11OSKKSRCAYETgRgBW4vQF3Y6pCgmThKD9oehYk3kkb/FsRgfqmsocmvAFqsiyjPIygg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.11",
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/core": "^1.6.15",
+				"@better-auth/utils": "0.4.1",
 				"@better-fetch/fetch": "1.1.21"
 			}
 		},
 		"node_modules/@better-auth/utils": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
-			"integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
+			"integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^2.0.1"
@@ -408,9 +408,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260604.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260604.1.tgz",
-			"integrity": "sha512-nVTydUwPcz9WfwZ/6xAmqs8uUVeGbDVmyPvSYrYAo4CQTyi0122SoE1Suw8RvqnN60XXHPChAjDqSIjnr/mbmg==",
+			"version": "4.20260608.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260608.1.tgz",
+			"integrity": "sha512-Yz90KXPZBB9K/AhsnLaA321s5+i5ZpWZRFbcGx9dWjyknQJXPAS1pK5CJSFEedwY6zoEr1cf2SkpBATL1idsWA==",
 			"devOptional": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -1330,9 +1330,9 @@
 			"optional": true
 		},
 		"node_modules/@fallow-cli/darwin-arm64": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.88.3.tgz",
-			"integrity": "sha512-lj3E3BevckfT9DHHN7iR/83pOHUA7cr+ynxarhiDNTlH6lklL5QqAb11nj+v7NzhSNQ+VzmwBLtuczrJEqeG7w==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.89.0.tgz",
+			"integrity": "sha512-moS850FVnDP4ZXY+79O7TA54s2ZmUe/bQpwsu+hkyOKAFeOqlHAoMM12IDiA+P/UBr4N2F+mEzMR65HgShdztQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1344,9 +1344,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/darwin-x64": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.88.3.tgz",
-			"integrity": "sha512-DFzP/aiMli2AflKiUMbRVye3PrEHaqeXLi/CnWd+8jECt6LATTeWiEJsDmHDaCfXgF4eaEuCMgosFaJo+ADqKw==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.89.0.tgz",
+			"integrity": "sha512-x3P4NEsLE71convKyFHIfuqXwyN9R7fzYCeMVAwHupB+gmIJyZfl+BiGJx4v1VXCS6pbUYn7X1UxHYhk1T/MPg==",
 			"cpu": [
 				"x64"
 			],
@@ -1358,9 +1358,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-arm64-gnu": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.88.3.tgz",
-			"integrity": "sha512-bfOtlJXr240a1ZslSjyYI3ZG8Y0qXHwT5gBAx7r5JDbDEmuPqcZv0xoMv+ZfJkHDepb1taeEfyX+77ekm+gXbA==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.89.0.tgz",
+			"integrity": "sha512-Nb6anWSulLkB0KDOEiqkbDn3VoSBQqfPyB3fUorPBMF+EJ6fOgwK8B/wenTEJf2Y4gy7ynUNJ1yITep1FJhqRA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1372,9 +1372,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-arm64-musl": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.88.3.tgz",
-			"integrity": "sha512-8Vt03oKYTVwQcXbVRR2OIQB5QfrJTm6D1kSUKUJ5deHPP+E5IiQBuQLLk9a6HhSnxOtNtIezCapDyz14Ztn3pw==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.89.0.tgz",
+			"integrity": "sha512-jkIwb53aG4OO0sXeqbF+WLKtAd1sAykQ9qhcVICu08/BVuISShkUL69T0jKBvAw0S4mfvaIitHvCmlsaBUQ0Ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -1386,9 +1386,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-x64-gnu": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.88.3.tgz",
-			"integrity": "sha512-LyKWd0nOqjbuQA/Bq6gbUiC1KO0O5fUSc3FQpnvmALX6Ia7ISppLWhbo0vQ0nnOvrywo6zhQrme6g7i04Y4tWg==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.89.0.tgz",
+			"integrity": "sha512-QLHmh0NRnAhELreLOZtcU4PJbHMFUoBq3J1DUSPfqQj6SqXsxAnARolsMGsg6bOEF3erj51ZWN22JUWYNOW76A==",
 			"cpu": [
 				"x64"
 			],
@@ -1400,9 +1400,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-x64-musl": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.88.3.tgz",
-			"integrity": "sha512-dxI+ZYupRNr4swaG8nkeCVnAQtut/fhgGMVS0tA6jJGY/2kjkkVze5uvMpfm4l41OEwZ5WsBhPAyXPP8DKx7xg==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.89.0.tgz",
+			"integrity": "sha512-wwvq/1/eiAJwLGuOlN4oF84Pp6RVKgIVGlIPBnXm5jyj5E+Iym8Ng1eGBBu2vtbUEZxumT6bexySIYMRSe+53g==",
 			"cpu": [
 				"x64"
 			],
@@ -1414,9 +1414,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/win32-arm64-msvc": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.88.3.tgz",
-			"integrity": "sha512-6HFe6csw4RQuGEOfXEZdkYmXVv5TZT0hMQalKSc1ny87s+yvY0DuCHoSpOglAGthPqlTB1MJB7/uLEMDRVWr8Q==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.89.0.tgz",
+			"integrity": "sha512-QyR0x2TVfkTxObZRC0gNTXXjiRbHeNyM0gBy1w5g/foos33lx2qdm9wrhM+/jmdDJZZME5DmXvGtnUoT4U+hug==",
 			"cpu": [
 				"arm64"
 			],
@@ -1428,9 +1428,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/win32-x64-msvc": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.88.3.tgz",
-			"integrity": "sha512-QPdOTlSoOj3ot29o+v4EaGuPq9ntOKVB4+OBxC31WG4ixjjwf+oHL9vk+tvyaIy2mooRSV0MKO/1m1NQkbJAmQ==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.89.0.tgz",
+			"integrity": "sha512-+3nT9JrQRSVQf67TlzzSRJWFE1hfxti8Sv719aVHcuzZhA/dcDEr4+fKQ5cBJc9eap75JAiRWUNzc69J2lVong==",
 			"cpu": [
 				"x64"
 			],
@@ -3257,9 +3257,9 @@
 			]
 		},
 		"node_modules/@oxfmt/binding-android-arm-eabi": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.53.0.tgz",
-			"integrity": "sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.54.0.tgz",
+			"integrity": "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==",
 			"cpu": [
 				"arm"
 			],
@@ -3274,9 +3274,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm64": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.53.0.tgz",
-			"integrity": "sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.54.0.tgz",
+			"integrity": "sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3291,9 +3291,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-arm64": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.53.0.tgz",
-			"integrity": "sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.54.0.tgz",
+			"integrity": "sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -3308,9 +3308,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-darwin-x64": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.53.0.tgz",
-			"integrity": "sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.54.0.tgz",
+			"integrity": "sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3325,9 +3325,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-freebsd-x64": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.53.0.tgz",
-			"integrity": "sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.54.0.tgz",
+			"integrity": "sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3342,9 +3342,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.53.0.tgz",
-			"integrity": "sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.54.0.tgz",
+			"integrity": "sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==",
 			"cpu": [
 				"arm"
 			],
@@ -3359,9 +3359,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.53.0.tgz",
-			"integrity": "sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.54.0.tgz",
+			"integrity": "sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==",
 			"cpu": [
 				"arm"
 			],
@@ -3376,9 +3376,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-gnu": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.53.0.tgz",
-			"integrity": "sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.54.0.tgz",
+			"integrity": "sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3396,9 +3396,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-arm64-musl": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.53.0.tgz",
-			"integrity": "sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.54.0.tgz",
+			"integrity": "sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3416,9 +3416,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.53.0.tgz",
-			"integrity": "sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.54.0.tgz",
+			"integrity": "sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3436,9 +3436,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.53.0.tgz",
-			"integrity": "sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.54.0.tgz",
+			"integrity": "sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3456,9 +3456,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-riscv64-musl": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.53.0.tgz",
-			"integrity": "sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.54.0.tgz",
+			"integrity": "sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3476,9 +3476,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-s390x-gnu": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.53.0.tgz",
-			"integrity": "sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.54.0.tgz",
+			"integrity": "sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==",
 			"cpu": [
 				"s390x"
 			],
@@ -3496,9 +3496,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-gnu": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.53.0.tgz",
-			"integrity": "sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.54.0.tgz",
+			"integrity": "sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==",
 			"cpu": [
 				"x64"
 			],
@@ -3516,9 +3516,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-linux-x64-musl": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.53.0.tgz",
-			"integrity": "sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.54.0.tgz",
+			"integrity": "sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==",
 			"cpu": [
 				"x64"
 			],
@@ -3536,9 +3536,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-openharmony-arm64": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.53.0.tgz",
-			"integrity": "sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.54.0.tgz",
+			"integrity": "sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3553,9 +3553,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-arm64-msvc": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.53.0.tgz",
-			"integrity": "sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.54.0.tgz",
+			"integrity": "sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3570,9 +3570,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-ia32-msvc": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.53.0.tgz",
-			"integrity": "sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.54.0.tgz",
+			"integrity": "sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==",
 			"cpu": [
 				"ia32"
 			],
@@ -3587,9 +3587,9 @@
 			}
 		},
 		"node_modules/@oxfmt/binding-win32-x64-msvc": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.53.0.tgz",
-			"integrity": "sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.54.0.tgz",
+			"integrity": "sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==",
 			"cpu": [
 				"x64"
 			],
@@ -3688,9 +3688,9 @@
 			]
 		},
 		"node_modules/@oxlint/binding-android-arm-eabi": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.68.0.tgz",
-			"integrity": "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
+			"integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
 			"cpu": [
 				"arm"
 			],
@@ -3705,9 +3705,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-android-arm64": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.68.0.tgz",
-			"integrity": "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
+			"integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3722,9 +3722,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-arm64": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.68.0.tgz",
-			"integrity": "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
+			"integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3739,9 +3739,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-x64": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.68.0.tgz",
-			"integrity": "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
+			"integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
 			"cpu": [
 				"x64"
 			],
@@ -3756,9 +3756,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-freebsd-x64": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.68.0.tgz",
-			"integrity": "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
+			"integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
 			"cpu": [
 				"x64"
 			],
@@ -3773,9 +3773,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.68.0.tgz",
-			"integrity": "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
+			"integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3790,9 +3790,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.68.0.tgz",
-			"integrity": "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
+			"integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
 			"cpu": [
 				"arm"
 			],
@@ -3807,9 +3807,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-gnu": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.68.0.tgz",
-			"integrity": "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
+			"integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3827,9 +3827,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-musl": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.68.0.tgz",
-			"integrity": "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
+			"integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3847,9 +3847,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.68.0.tgz",
-			"integrity": "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
+			"integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3867,9 +3867,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.68.0.tgz",
-			"integrity": "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
+			"integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3887,9 +3887,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-musl": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.68.0.tgz",
-			"integrity": "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
+			"integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3907,9 +3907,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-s390x-gnu": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.68.0.tgz",
-			"integrity": "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
+			"integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
 			"cpu": [
 				"s390x"
 			],
@@ -3927,9 +3927,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.68.0.tgz",
-			"integrity": "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
+			"integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3947,9 +3947,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-musl": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.68.0.tgz",
-			"integrity": "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
+			"integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
 			"cpu": [
 				"x64"
 			],
@@ -3967,9 +3967,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-openharmony-arm64": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.68.0.tgz",
-			"integrity": "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
+			"integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3984,9 +3984,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-arm64-msvc": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.68.0.tgz",
-			"integrity": "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
+			"integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4001,9 +4001,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-ia32-msvc": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.68.0.tgz",
-			"integrity": "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
+			"integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
 			"cpu": [
 				"ia32"
 			],
@@ -4018,9 +4018,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-x64-msvc": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.68.0.tgz",
-			"integrity": "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
+			"integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
 			"cpu": [
 				"x64"
 			],
@@ -4965,9 +4965,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.63.0.tgz",
-			"integrity": "sha512-1DrR7vQ9brXLrNE2sLtFXApwr7AUXPfpbIFYc+CQRf2+iURaZbXGU+7TG/RLr+9fdFkoRdyCAVUOHCChw11LFA==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.64.0.tgz",
+			"integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5316,16 +5316,16 @@
 			}
 		},
 		"node_modules/@tailwindcss/typography": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-			"integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+			"version": "0.5.20",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+			"integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "6.0.10"
 			},
 			"peerDependencies": {
-				"tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+				"tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
@@ -5500,9 +5500,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"version": "25.9.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+			"integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5566,9 +5566,9 @@
 			}
 		},
 		"node_modules/@valibot/to-json-schema": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.0.tgz",
-			"integrity": "sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.1.tgz",
+			"integrity": "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -5931,26 +5931,26 @@
 			"license": "MIT"
 		},
 		"node_modules/better-auth": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.11.tgz",
-			"integrity": "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==",
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.15.tgz",
+			"integrity": "sha512-0nuQuEru3ZrLF+9xFUuN3llAmR+6gHLtLunoXaZxB9lXGjSmfBcc6SZUgYq4DfzugPnLvdnzYazsyprZFSFC4Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@better-auth/core": "1.6.11",
-				"@better-auth/drizzle-adapter": "1.6.11",
-				"@better-auth/kysely-adapter": "1.6.11",
-				"@better-auth/memory-adapter": "1.6.11",
-				"@better-auth/mongo-adapter": "1.6.11",
-				"@better-auth/prisma-adapter": "1.6.11",
-				"@better-auth/telemetry": "1.6.11",
-				"@better-auth/utils": "0.4.0",
+				"@better-auth/core": "1.6.15",
+				"@better-auth/drizzle-adapter": "1.6.15",
+				"@better-auth/kysely-adapter": "1.6.15",
+				"@better-auth/memory-adapter": "1.6.15",
+				"@better-auth/mongo-adapter": "1.6.15",
+				"@better-auth/prisma-adapter": "1.6.15",
+				"@better-auth/telemetry": "1.6.15",
+				"@better-auth/utils": "0.4.1",
 				"@better-fetch/fetch": "1.1.21",
 				"@noble/ciphers": "^2.1.1",
 				"@noble/hashes": "^2.0.1",
 				"better-call": "1.3.5",
 				"defu": "^6.1.4",
 				"jose": "^6.1.3",
-				"kysely": "^0.28.17",
+				"kysely": "^0.28.17 || ^0.29.0",
 				"nanostores": "^1.1.1",
 				"zod": "^4.3.6"
 			},
@@ -7541,9 +7541,9 @@
 			}
 		},
 		"node_modules/effect": {
-			"version": "3.21.2",
-			"resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
-			"integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+			"version": "3.21.3",
+			"resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+			"integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -7616,9 +7616,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.22.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
-			"integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
+			"integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7790,9 +7790,9 @@
 			}
 		},
 		"node_modules/fallow": {
-			"version": "2.88.3",
-			"resolved": "https://registry.npmjs.org/fallow/-/fallow-2.88.3.tgz",
-			"integrity": "sha512-vXgg/5G5jbx4p8Ff3U3I/nlCfO9ntvJLz5Ut7kUnvuE2Z9ubYtwMY2ZlD4af0i8WQFRvdWS2qwlCfeYP1bMg0A==",
+			"version": "2.89.0",
+			"resolved": "https://registry.npmjs.org/fallow/-/fallow-2.89.0.tgz",
+			"integrity": "sha512-q5gKY084d6ycCanOMVhdw5wXfWR7+octSD8EMh+UsJdKlt8vr7EaCPX37CPdJ4Rj1SDf2fVThpdmeBgLi4XsrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7807,14 +7807,14 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@fallow-cli/darwin-arm64": "2.88.3",
-				"@fallow-cli/darwin-x64": "2.88.3",
-				"@fallow-cli/linux-arm64-gnu": "2.88.3",
-				"@fallow-cli/linux-arm64-musl": "2.88.3",
-				"@fallow-cli/linux-x64-gnu": "2.88.3",
-				"@fallow-cli/linux-x64-musl": "2.88.3",
-				"@fallow-cli/win32-arm64-msvc": "2.88.3",
-				"@fallow-cli/win32-x64-msvc": "2.88.3"
+				"@fallow-cli/darwin-arm64": "2.89.0",
+				"@fallow-cli/darwin-x64": "2.89.0",
+				"@fallow-cli/linux-arm64-gnu": "2.89.0",
+				"@fallow-cli/linux-arm64-musl": "2.89.0",
+				"@fallow-cli/linux-x64-gnu": "2.89.0",
+				"@fallow-cli/linux-x64-musl": "2.89.0",
+				"@fallow-cli/win32-arm64-msvc": "2.89.0",
+				"@fallow-cli/win32-x64-msvc": "2.89.0"
 			}
 		},
 		"node_modules/fast-check": {
@@ -8280,9 +8280,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.15.0.tgz",
-			"integrity": "sha512-uBaKFEGcu/HG4EY2gWFBMr+fBF43Jftoc2riJX51TKME1Z46C8UQIbNEusenYbEWihphxe2PY0Kns0yPvPYz4A==",
+			"version": "6.16.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.16.1.tgz",
+			"integrity": "sha512-TKMn1rxgH6h9vXR9Y0B+Cq7AdPTr9EI02IwoT65NzqYUkvoDQAaJ/aPybiFpAhZ1px6cNYYwXf86iHkBgzCo9w==",
 			"dev": true,
 			"funding": [
 				{
@@ -8300,7 +8300,6 @@
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
 				"jiti": "^2.7.0",
-				"minimist": "^1.2.8",
 				"oxc-parser": "^0.133.0",
 				"oxc-resolver": "^11.20.0",
 				"picomatch": "^4.0.4",
@@ -8320,12 +8319,12 @@
 			}
 		},
 		"node_modules/kysely": {
-			"version": "0.28.17",
-			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
-			"integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+			"version": "0.29.2",
+			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
+			"integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/layerchart": {
@@ -8562,9 +8561,9 @@
 			]
 		},
 		"node_modules/libphonenumber-js": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
-			"integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+			"integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true
@@ -9454,9 +9453,9 @@
 			}
 		},
 		"node_modules/oxfmt": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.53.0.tgz",
-			"integrity": "sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==",
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.54.0.tgz",
+			"integrity": "sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9472,25 +9471,25 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxfmt/binding-android-arm-eabi": "0.53.0",
-				"@oxfmt/binding-android-arm64": "0.53.0",
-				"@oxfmt/binding-darwin-arm64": "0.53.0",
-				"@oxfmt/binding-darwin-x64": "0.53.0",
-				"@oxfmt/binding-freebsd-x64": "0.53.0",
-				"@oxfmt/binding-linux-arm-gnueabihf": "0.53.0",
-				"@oxfmt/binding-linux-arm-musleabihf": "0.53.0",
-				"@oxfmt/binding-linux-arm64-gnu": "0.53.0",
-				"@oxfmt/binding-linux-arm64-musl": "0.53.0",
-				"@oxfmt/binding-linux-ppc64-gnu": "0.53.0",
-				"@oxfmt/binding-linux-riscv64-gnu": "0.53.0",
-				"@oxfmt/binding-linux-riscv64-musl": "0.53.0",
-				"@oxfmt/binding-linux-s390x-gnu": "0.53.0",
-				"@oxfmt/binding-linux-x64-gnu": "0.53.0",
-				"@oxfmt/binding-linux-x64-musl": "0.53.0",
-				"@oxfmt/binding-openharmony-arm64": "0.53.0",
-				"@oxfmt/binding-win32-arm64-msvc": "0.53.0",
-				"@oxfmt/binding-win32-ia32-msvc": "0.53.0",
-				"@oxfmt/binding-win32-x64-msvc": "0.53.0"
+				"@oxfmt/binding-android-arm-eabi": "0.54.0",
+				"@oxfmt/binding-android-arm64": "0.54.0",
+				"@oxfmt/binding-darwin-arm64": "0.54.0",
+				"@oxfmt/binding-darwin-x64": "0.54.0",
+				"@oxfmt/binding-freebsd-x64": "0.54.0",
+				"@oxfmt/binding-linux-arm-gnueabihf": "0.54.0",
+				"@oxfmt/binding-linux-arm-musleabihf": "0.54.0",
+				"@oxfmt/binding-linux-arm64-gnu": "0.54.0",
+				"@oxfmt/binding-linux-arm64-musl": "0.54.0",
+				"@oxfmt/binding-linux-ppc64-gnu": "0.54.0",
+				"@oxfmt/binding-linux-riscv64-gnu": "0.54.0",
+				"@oxfmt/binding-linux-riscv64-musl": "0.54.0",
+				"@oxfmt/binding-linux-s390x-gnu": "0.54.0",
+				"@oxfmt/binding-linux-x64-gnu": "0.54.0",
+				"@oxfmt/binding-linux-x64-musl": "0.54.0",
+				"@oxfmt/binding-openharmony-arm64": "0.54.0",
+				"@oxfmt/binding-win32-arm64-msvc": "0.54.0",
+				"@oxfmt/binding-win32-ia32-msvc": "0.54.0",
+				"@oxfmt/binding-win32-x64-msvc": "0.54.0"
 			},
 			"peerDependencies": {
 				"svelte": "^5.0.0",
@@ -9506,9 +9505,9 @@
 			}
 		},
 		"node_modules/oxlint": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.68.0.tgz",
-			"integrity": "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==",
+			"version": "1.69.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
+			"integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -9521,25 +9520,25 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.68.0",
-				"@oxlint/binding-android-arm64": "1.68.0",
-				"@oxlint/binding-darwin-arm64": "1.68.0",
-				"@oxlint/binding-darwin-x64": "1.68.0",
-				"@oxlint/binding-freebsd-x64": "1.68.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.68.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.68.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.68.0",
-				"@oxlint/binding-linux-arm64-musl": "1.68.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.68.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.68.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.68.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.68.0",
-				"@oxlint/binding-linux-x64-gnu": "1.68.0",
-				"@oxlint/binding-linux-x64-musl": "1.68.0",
-				"@oxlint/binding-openharmony-arm64": "1.68.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.68.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.68.0",
-				"@oxlint/binding-win32-x64-msvc": "1.68.0"
+				"@oxlint/binding-android-arm-eabi": "1.69.0",
+				"@oxlint/binding-android-arm64": "1.69.0",
+				"@oxlint/binding-darwin-arm64": "1.69.0",
+				"@oxlint/binding-darwin-x64": "1.69.0",
+				"@oxlint/binding-freebsd-x64": "1.69.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.69.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.69.0",
+				"@oxlint/binding-linux-arm64-musl": "1.69.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.69.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.69.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.69.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.69.0",
+				"@oxlint/binding-linux-x64-gnu": "1.69.0",
+				"@oxlint/binding-linux-x64-musl": "1.69.0",
+				"@oxlint/binding-openharmony-arm64": "1.69.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.69.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.69.0",
+				"@oxlint/binding-win32-x64-msvc": "1.69.0"
 			},
 			"peerDependencies": {
 				"oxlint-tsgolint": ">=0.22.1",
@@ -10100,9 +10099,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-			"integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -10451,9 +10450,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.2",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.2.tgz",
-			"integrity": "sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==",
+			"version": "5.56.3",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
+			"integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -10931,9 +10930,9 @@
 			}
 		},
 		"node_modules/typebox": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.0.tgz",
-			"integrity": "sha512-5zmwtMQArPorr1PVqo5Ye3GRmaiHQ7iicRnlmRXWWDLg5k5fky8OG40B12ckVq5YIxpGM8s1qzcfcA8SKNjPVw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.3.tgz",
+			"integrity": "sha512-EdFz/9FGvhQK2NmjZjSLri+nd5oMH+t/46/6lueEPbeHmS9WbWOz5IayPyLw0HHIyOWfo+wPrQGcAEQ+GsXc/w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"layerchart": "^2.0.0-next.51",
 		"lefthook": "^2.1.9",
 		"lint-staged": "^17.0.7",
-		"oxfmt": "^0.53.0",
+		"oxfmt": "^0.54.0",
 		"oxlint": "^1.67.0",
 		"oxlint-tsgolint": "^0.23.0",
 		"svelte": "^5.55.1",


### PR DESCRIPTION
Upgrade the `oxfmt` dependency to version 0.54.0 to ensure compatibility and take advantage of the latest features and fixes.