### PR TITLE
fix(auth): prevent 500 on invalid sign-in credentials

### DIFF
--- a/src/routes/(auth)/sign-in/+page.server.ts
+++ b/src/routes/(auth)/sign-in/+page.server.ts
@@ -24,11 +24,7 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(loginSchema));
 
 		if (!form.valid) {
-			return message(
-				form,
-				{ type: 'error', text: 'Please correct the errors in the form.' },
-				{ status: 400 }
-			);
+			return message(form, 'Please correct the errors in the form.', { status: 400 });
 		}
 
 		try {
@@ -48,7 +44,7 @@ export const actions: Actions = {
 			);
 			logger.error('Sign-in failed', error);
 
-			return message(form, { type: 'error', text: errorMessage }, { status: 400 });
+			return message(form, errorMessage, { status: 400 });
 		}
 	}
 };


### PR DESCRIPTION
## Summary
- return plain string form messages in the sign-in action instead of structured `{ type, text }` objects
- keep the sign-in page behavior unchanged while ensuring invalid credentials render as a form error instead of triggering a server render crash

## Why
Issue #239 reported that an invalid password produced a 500 error (`includes is not a function`) instead of returning to the sign-in page with a user-facing error.

This fix keeps message types consistent with how the sign-in page and superforms message store are consumed.

## Validation
- `npm run check` passed
- pre-push tests passed (`26` test files, `321` tests)

Closes #239