### PR TITLE
fix(auth): add loading spinner feedback for auth submits

### DIFF
--- a/src/lib/components/ui/spinner/index.ts
+++ b/src/lib/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/src/lib/components/ui/spinner/spinner.svelte
+++ b/src/lib/components/ui/spinner/spinner.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import type { SVGAttributes } from "svelte/elements";
+
+	let {
+		class: className,
+		role = "status",
+		// we add name, color, and stroke for compatibility with different icon libraries props
+		name,
+		color,
+		stroke,
+		"aria-label": ariaLabel = "Loading",
+		...restProps
+	}: SVGAttributes<SVGSVGElement> = $props();
+</script>
+
+<Loader2Icon {role} name={name === null ? undefined : name} color={color === null ? undefined : color} stroke={stroke === null ? undefined : stroke} aria-label={ariaLabel} class={cn("size-4 animate-spin", className)} {...restProps} />

--- a/src/routes/(auth)/forgot-password/+page.svelte
+++ b/src/routes/(auth)/forgot-password/+page.svelte
@@ -8,6 +8,7 @@
 		FieldLabel
 	} from '$lib/components/ui/field/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { superForm } from 'sveltekit-superforms';
 
 	let { data } = $props();
@@ -87,6 +88,9 @@
 					</Field>
 
 					<Button type="submit" class="w-full" disabled={$submitting}>
+						{#if $submitting}
+							<Spinner class="mr-2 size-4" aria-label="Sending reset link" />
+						{/if}
 						{$submitting ? 'Sending...' : 'Send reset link'}
 					</Button>
 

--- a/src/routes/(auth)/register/+page.svelte
+++ b/src/routes/(auth)/register/+page.svelte
@@ -8,6 +8,7 @@
 		FieldLabel
 	} from '$lib/components/ui/field/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { superForm } from 'sveltekit-superforms';
 
 	let { data } = $props();
@@ -108,6 +109,9 @@
 
 			<Field>
 				<Button type="submit" class="w-full" disabled={$submitting}>
+					{#if $submitting}
+						<Spinner class="mr-2 size-4" aria-label="Creating account" />
+					{/if}
 					{$submitting ? 'Creating account...' : 'Sign up'}
 				</Button>
 				<FieldDescription class="text-center">

--- a/src/routes/(auth)/reset-password/+page.svelte
+++ b/src/routes/(auth)/reset-password/+page.svelte
@@ -4,6 +4,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Field, FieldGroup, FieldLabel } from '$lib/components/ui/field/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
@@ -111,6 +112,9 @@
 
 					<Field>
 						<Button type="submit" class="w-full" disabled={$submitting}>
+							{#if $submitting}
+								<Spinner class="mr-2 size-4" aria-label="Resetting password" />
+							{/if}
 							{$submitting ? 'Resetting password...' : 'Reset password'}
 						</Button>
 					</Field>

--- a/src/routes/(auth)/sign-in/+page.svelte
+++ b/src/routes/(auth)/sign-in/+page.svelte
@@ -9,6 +9,7 @@
 		FieldLabel
 	} from '$lib/components/ui/field/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { superForm } from 'sveltekit-superforms';
 
 	let { data } = $props();
@@ -104,6 +105,9 @@
 				</Field>
 				<Field>
 					<Button type="submit" class="w-full" disabled={$submitting}>
+						{#if $submitting}
+							<Spinner class="mr-2 size-4" aria-label="Signing in" />
+						{/if}
 						{$submitting ? 'Signing in...' : 'Sign in'}
 					</Button>
 					<FieldDescription class="text-center">


### PR DESCRIPTION
## Summary
- add the shadcn-svelte Spinner component under src/lib/components/ui/spinner
- show inline loading spinners inside submit buttons for sign-in, register, forgot-password, and reset-password forms
- keep existing disabled and loading text behavior so users get immediate visual feedback on submit

## Testing
- npm run lint
- npm run check
- npm run test

Closes #240