### PR TITLE
feat: add human-readable nearby date labels

### DIFF
--- a/src/lib/components/journal/JournalEntryCard.svelte
+++ b/src/lib/components/journal/JournalEntryCard.svelte
@@ -3,7 +3,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import type { JournalEntry } from '$lib/types';
-	import { formatDateLong } from '$lib/utils/date';
+	import { formatDateHeuristic } from '$lib/utils/date';
 	import { Calendar, Cloud, MapPin, Pencil, Trash2 } from '@lucide/svelte/icons';
 	import { marked } from 'marked';
 
@@ -41,7 +41,7 @@
 						class="inline-flex items-center gap-2 rounded-md transition-colors hover:text-[oklch(var(--color-blue))] focus-visible:text-[oklch(var(--color-blue))]"
 					>
 						<Calendar class="h-4 w-4 shrink-0 opacity-70" />
-						<span>{formatDateLong(entry.date)}</span>
+						<span>{formatDateHeuristic(entry.date, { fallback: 'long' })}</span>
 					</a>
 				</Card.Title>
 			</div>

--- a/src/lib/components/tasks/TaskCard.svelte
+++ b/src/lib/components/tasks/TaskCard.svelte
@@ -11,7 +11,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import type { TaskState } from '$lib/schemas/task';
-	import { formatDateMedium, getDateUrgencyStatus } from '$lib/utils/date';
+	import { formatDateHeuristic, getDateUrgencyStatus } from '$lib/utils/date';
 	import { Calendar, CircleCheck, EllipsisVertical, Pencil, Trash2 } from '@lucide/svelte/icons';
 
 	interface Props {
@@ -31,7 +31,7 @@
 	let editHref = $derived(`/tasks/${task.id}/edit`);
 	let isDoneTask = $derived(task.state === 'done');
 	let isBlockedTask = $derived(task.state === 'blocked');
-	let dueDateLabel = $derived(task.dueDate ? formatDateMedium(task.dueDate) : null);
+	let dueDateLabel = $derived(task.dueDate ? formatDateHeuristic(task.dueDate) : null);
 	let dueDateStatus = $derived(getDateUrgencyStatus(task.dueDate));
 	let hasFooterMeta = $derived(Boolean(dueDateLabel) || Boolean(task.tags?.length));
 	let dueDateClass = $derived(

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	addDaysToDateString,
+	formatDateHeuristic,
 	formatDateLong,
 	formatDateMedium,
 	formatDateShort,
 	formatTime12Hour,
+	formatTimestampDateHeuristic,
 	formatTimeFromTimestamp,
 	formatTimestampLong,
 	formatTimestampMedium,
 	formatTimestampShort,
 	getDateRange,
+	getRelativeDateLabel,
 	getDateUrgencyStatus,
 	getRollingDateRange,
 	getStartOfMonth,
@@ -148,6 +151,27 @@ describe('date display formatters', () => {
 		expect(formatted).toContain('2026');
 		expect(formatted).not.toContain('Mon');
 	});
+
+	it('returns heuristic labels for yesterday, today, and tomorrow', () => {
+		expect(getRelativeDateLabel('2026-03-08', '2026-03-09')).toBe('Yesterday');
+		expect(getRelativeDateLabel('2026-03-09', '2026-03-09')).toBe('Today');
+		expect(getRelativeDateLabel('2026-03-10', '2026-03-09')).toBe('Tomorrow');
+	});
+
+	it('uses heuristic labels by default and falls back to absolute formatting for other dates', () => {
+		expect(formatDateHeuristic('2026-03-08', { today: '2026-03-09' })).toBe('Yesterday');
+		expect(formatDateHeuristic('2026-03-12', { today: '2026-03-09' })).toBe('Thu, Mar 12');
+	});
+
+	it('can include the absolute date alongside a heuristic label', () => {
+		expect(
+			formatDateHeuristic('2026-03-10', {
+				today: '2026-03-09',
+				fallback: 'medium',
+				includeAbsoluteDate: true
+			})
+		).toBe('Tomorrow · Tue, Mar 10');
+	});
 });
 
 describe('timestamp formatters', () => {
@@ -172,6 +196,19 @@ describe('timestamp formatters', () => {
 	it('extracts just the time portion from a timestamp', () => {
 		const formatted = formatTimeFromTimestamp('2026-03-09T14:30:00.000Z');
 		expect(formatted).toContain('30');
+	});
+
+	it('formats timestamp dates with heuristic labels using Pacific time', () => {
+		expect(
+			formatTimestampDateHeuristic('2026-03-13T06:59:59.000Z', {
+				today: '2026-03-13'
+			})
+		).toBe('Yesterday');
+		expect(
+			formatTimestampDateHeuristic('2026-03-13T07:00:00.000Z', {
+				today: '2026-03-13'
+			})
+		).toBe('Today');
 	});
 
 	it('converts 24-hour time to 12-hour AM/PM format', () => {

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -124,6 +124,64 @@ export function formatMonthDay(dateString: string): string {
 	});
 }
 
+type DateDisplayFormat = 'long' | 'medium' | 'short' | 'monthDay';
+
+function formatDateByStyle(dateString: string, format: DateDisplayFormat): string {
+	switch (format) {
+		case 'long':
+			return formatDateLong(dateString);
+		case 'medium':
+			return formatDateMedium(dateString);
+		case 'short':
+			return formatDateShort(dateString);
+		case 'monthDay':
+			return formatMonthDay(dateString);
+	}
+}
+
+export function getRelativeDateLabel(
+	dateString: string,
+	today: string = getTodayString()
+): 'Yesterday' | 'Today' | 'Tomorrow' | null {
+	switch (calendarDaysBetween(today, dateString)) {
+		case -1:
+			return 'Yesterday';
+		case 0:
+			return 'Today';
+		case 1:
+			return 'Tomorrow';
+		default:
+			return null;
+	}
+}
+
+interface HeuristicDateOptions {
+	today?: string;
+	fallback?: DateDisplayFormat;
+	includeAbsoluteDate?: boolean;
+}
+
+export function formatDateHeuristic(
+	dateString: string,
+	{
+		today = getTodayString(),
+		fallback = 'medium',
+		includeAbsoluteDate = false
+	}: HeuristicDateOptions = {}
+): string {
+	const relativeLabel = getRelativeDateLabel(dateString, today);
+
+	if (!relativeLabel) {
+		return formatDateByStyle(dateString, fallback);
+	}
+
+	if (includeAbsoluteDate) {
+		return `${relativeLabel} · ${formatDateByStyle(dateString, fallback)}`;
+	}
+
+	return relativeLabel;
+}
+
 /**
  * Format today's date as a long display label using the app timezone.
  *
@@ -271,6 +329,14 @@ export function formatTimestampShort(timestamp: string): string {
 		day: 'numeric',
 		year: 'numeric'
 	});
+}
+
+export function formatTimestampDateHeuristic(
+	timestamp: string,
+	options: HeuristicDateOptions = {}
+): string {
+	const dateString = formatDateParts(new Date(timestamp), appDateFormatter);
+	return formatDateHeuristic(dateString, options);
 }
 
 /**

--- a/src/routes/(app)/meditation/+page.svelte
+++ b/src/routes/(app)/meditation/+page.svelte
@@ -16,7 +16,7 @@
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { formatTimeFromTimestamp, formatTimestampShort } from '$lib/utils/date';
+	import { formatTimeFromTimestamp, formatTimestampDateHeuristic } from '$lib/utils/date';
 	import {
 		CirclePlay,
 		Clock,
@@ -342,7 +342,7 @@
 										<div class="flex-1">
 											<h3 class="font-medium">{session.routine.title}</h3>
 											<p class="text-muted-foreground text-sm">
-												{formatTimestampShort(session.completedAt)}
+												{formatTimestampDateHeuristic(session.completedAt, { fallback: 'short' })}
 												at
 												{formatTimeFromTimestamp(session.completedAt)}
 											</p>

--- a/src/routes/(app)/visits/+page.svelte
+++ b/src/routes/(app)/visits/+page.svelte
@@ -8,7 +8,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
-	import { formatDateShort } from '$lib/utils/date';
+	import { formatDateHeuristic } from '$lib/utils/date';
 	import { getStatusLabel, type VisitStatus } from '$lib/utils/visit-status';
 	import { CalendarCheck, Plus } from '@lucide/svelte';
 
@@ -251,12 +251,16 @@
 															<CalendarCheck class="h-4 w-4" />
 															<Alert.Title>Follow-up scheduled:</Alert.Title>
 															<Alert.Description>
-																{formatDateShort(person.nextFollowUpDate)}
+																{formatDateHeuristic(person.nextFollowUpDate, {
+																	fallback: 'short'
+																})}
 															</Alert.Description>
 														</Alert.Root>
 													{/if}
 													<p>
-														Last visit: {formatDateShort(person.lastVisit.date)}
+														Last visit: {formatDateHeuristic(person.lastVisit.date, {
+															fallback: 'short'
+														})}
 														{#if person.daysSinceLastVisit !== null}
 															({formatTimeSince(person.daysSinceLastVisit)})
 														{/if}


### PR DESCRIPTION
## Summary\n- add shared Pacific-time-aware heuristic date helpers for Yesterday, Today, and Tomorrow\n- apply the new label-only default to task cards, journal entries, visit summaries, and meditation session history\n- keep absolute-date fallbacks for non-nearby dates and add regression coverage for heuristic/timestamp behavior\n\n## Testing\n- npm run check\n- npm run lint\n- npm run test\n- npm run build\n\nCloses #237