### PR TITLE
Deduplicate weather JSON and task tag parsing

### DIFF
--- a/src/lib/schemas/journal.test.ts
+++ b/src/lib/schemas/journal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { journalEntrySchema, journalFilterSchema } from './journal';
+import { buildWeatherJson, journalEntrySchema, journalFilterSchema } from './journal';
 
 describe('journalEntrySchema', () => {
 	const validEntry = {
@@ -59,5 +59,23 @@ describe('journalFilterSchema', () => {
 
 	it('rejects an invalid date format in the filter', () => {
 		expect(journalFilterSchema.safeParse({ date: 'not-a-date' }).success).toBe(false);
+	});
+});
+
+describe('buildWeatherJson', () => {
+	it('serializes temp and condition when both are present', () => {
+		expect(buildWeatherJson(72, 'Sunny')).toBe('{"temp":72,"condition":"Sunny"}');
+	});
+
+	it('serializes when only temp is present', () => {
+		expect(buildWeatherJson(72, undefined)).toBe('{"temp":72}');
+	});
+
+	it('serializes when only condition is present', () => {
+		expect(buildWeatherJson(undefined, 'Cloudy')).toBe('{"condition":"Cloudy"}');
+	});
+
+	it('returns null when neither temp nor condition are present', () => {
+		expect(buildWeatherJson(undefined, undefined)).toBeNull();
 	});
 });

--- a/src/lib/schemas/journal.ts
+++ b/src/lib/schemas/journal.ts
@@ -14,6 +14,16 @@ export const journalEntrySchema = z.object({
 export type JournalEntryFormValues = z.infer<typeof journalEntrySchema>;
 
 /**
+ * Serializes weather form fields into the JSON string stored on a journal entry.
+ */
+export function buildWeatherJson(
+	temp: number | undefined,
+	condition: string | undefined
+): string | null {
+	return temp || condition ? JSON.stringify({ temp, condition }) : null;
+}
+
+/**
  * Schema for filtering journal entries
  */
 export const journalFilterSchema = z.object({

--- a/src/lib/server/actions/string-parsers.test.ts
+++ b/src/lib/server/actions/string-parsers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { splitCommaSeparated, toCommaSeparatedJson } from './string-parsers';
+import { parseTaskTags, splitCommaSeparated, toCommaSeparatedJson } from './string-parsers';
 
 describe('splitCommaSeparated', () => {
 	it('splits a comma-separated string into trimmed items', () => {
@@ -48,5 +48,31 @@ describe('toCommaSeparatedJson', () => {
 
 	it('returns a single-element JSON array for a single value', () => {
 		expect(toCommaSeparatedJson('item')).toBe('["item"]');
+	});
+});
+
+describe('parseTaskTags', () => {
+	it('parses a JSON array string into an array of tags', () => {
+		expect(parseTaskTags('["alpha","beta"]')).toEqual(['alpha', 'beta']);
+	});
+
+	it('returns null for null, undefined, and empty string', () => {
+		expect(parseTaskTags(null)).toBeNull();
+		expect(parseTaskTags(undefined)).toBeNull();
+		expect(parseTaskTags('')).toBeNull();
+	});
+
+	it('returns null for malformed JSON', () => {
+		expect(parseTaskTags('not json')).toBeNull();
+	});
+
+	it('returns null when the parsed JSON is not an array of strings', () => {
+		expect(parseTaskTags('{"a":1}')).toBeNull();
+		expect(parseTaskTags('[1,2,3]')).toBeNull();
+		expect(parseTaskTags('"just a string"')).toBeNull();
+	});
+
+	it('returns an empty array when stored tags are an empty JSON array', () => {
+		expect(parseTaskTags('[]')).toEqual([]);
 	});
 });

--- a/src/lib/server/actions/string-parsers.ts
+++ b/src/lib/server/actions/string-parsers.ts
@@ -1,3 +1,27 @@
+import { z } from 'zod';
+
+const taskTagsSchema = z.array(z.string());
+
+/**
+ * Parses a task's stored JSON tags string, returning null for missing,
+ * malformed, or non-array data instead of throwing.
+ */
+export function parseTaskTags(rawTags: string | null | undefined): string[] | null {
+	if (!rawTags) {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawTags);
+	} catch {
+		return null;
+	}
+
+	const result = taskTagsSchema.safeParse(parsed);
+	return result.success ? result.data : null;
+}
+
 export function splitCommaSeparated(value: string | null | undefined): string[] {
 	if (!value) {
 		return [];

--- a/src/routes/(app)/journal/[id]/+page.server.ts
+++ b/src/routes/(app)/journal/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import { logger } from '$lib';
-import { journalEntrySchema } from '$lib/schemas/journal';
+import { buildWeatherJson, journalEntrySchema } from '$lib/schemas/journal';
 import { getUser, requireAuth } from '$lib/server/actions/auth-guard';
 import { getDb } from '$lib/server/db';
 import { journalEntries } from '$lib/server/db/schema';
@@ -50,13 +50,7 @@ export const actions: Actions = {
 			const db = getDb();
 			const location = form.data.location?.trim() || 'Home';
 
-			const weather =
-				form.data.weatherTemp || form.data.weatherCondition
-					? JSON.stringify({
-							temp: form.data.weatherTemp,
-							condition: form.data.weatherCondition
-						})
-					: null;
+			const weather = buildWeatherJson(form.data.weatherTemp, form.data.weatherCondition);
 
 			await db
 				.update(journalEntries)

--- a/src/routes/(app)/journal/new/+page.server.ts
+++ b/src/routes/(app)/journal/new/+page.server.ts
@@ -1,5 +1,5 @@
 import { logger } from '$lib';
-import { journalEntrySchema } from '$lib/schemas/journal';
+import { buildWeatherJson, journalEntrySchema } from '$lib/schemas/journal';
 import { requireAuth } from '$lib/server/actions/auth-guard';
 import { getDb } from '$lib/server/db';
 import { journalEntries } from '$lib/server/db/schema';
@@ -32,13 +32,7 @@ export const actions: Actions = {
 		try {
 			const location = form.data.location?.trim() || 'Home';
 
-			const weather =
-				form.data.weatherTemp || form.data.weatherCondition
-					? JSON.stringify({
-							temp: form.data.weatherTemp,
-							condition: form.data.weatherCondition
-						})
-					: null;
+			const weather = buildWeatherJson(form.data.weatherTemp, form.data.weatherCondition);
 
 			const entryId = generateId();
 

--- a/src/routes/(app)/tasks/+page.server.ts
+++ b/src/routes/(app)/tasks/+page.server.ts
@@ -18,6 +18,7 @@ import {
 	updateTaskStateSchema
 } from '$lib/schemas/task';
 import { getUser, requireAuth } from '$lib/server/actions/auth-guard';
+import { parseTaskTags } from '$lib/server/actions/string-parsers';
 import {
 	createDailyAgendaCustomEntry,
 	createDailyAgendaTemplate,
@@ -211,34 +212,12 @@ async function getAllTags(userId: string): Promise<string[]> {
 
 	const tagSet = new Set<string>();
 	for (const task of taskRows) {
-		if (task.tags) {
-			try {
-				const tagArray = JSON.parse(task.tags);
-				if (Array.isArray(tagArray)) {
-					for (const tag of tagArray) {
-						tagSet.add(tag);
-					}
-				}
-			} catch {
-				// Skip invalid JSON
-			}
+		for (const tag of parseTaskTags(task.tags) ?? []) {
+			tagSet.add(tag);
 		}
 	}
 
 	return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
-}
-
-function parseStoredTags(rawTags: string | null): string[] | null {
-	if (!rawTags) {
-		return null;
-	}
-
-	try {
-		const parsed = JSON.parse(rawTags);
-		return Array.isArray(parsed) ? parsed : null;
-	} catch {
-		return null;
-	}
 }
 
 type TaskBoardClient = Pick<ReturnType<typeof getDb>, 'select' | 'update'>;
@@ -428,7 +407,7 @@ async function loadTaskBoardData(
 		...task,
 		taskNumber: task.taskNumber,
 		state: task.state as TaskState,
-		tags: parseStoredTags(task.tags)
+		tags: parseTaskTags(task.tags)
 	}));
 }
 

--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -10,7 +10,7 @@ import {
 	getOwnedEntityOrNull,
 	getOwnedEntityOrThrow
 } from '$lib/server/actions/edit-route-helpers';
-import { toCommaSeparatedJson } from '$lib/server/actions/string-parsers';
+import { parseTaskTags, toCommaSeparatedJson } from '$lib/server/actions/string-parsers';
 import { getDb } from '$lib/server/db';
 import { tasks } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
@@ -57,8 +57,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	);
 
 	// Parse JSON fields for form
-	const tagsArray = task.tags ? JSON.parse(task.tags) : [];
-	const tagsString = Array.isArray(tagsArray) ? tagsArray.join(', ') : '';
+	const tagsString = (parseTaskTags(task.tags) ?? []).join(', ');
 
 	// Prepare form data
 	const form = await superValidate(


### PR DESCRIPTION
## Summary
- Closes #249: extracts `buildWeatherJson` into `src/lib/schemas/journal.ts` so the journal create and edit routes share one serialization path instead of duplicating the same inline `JSON.stringify` logic.
- Closes #250: extracts `parseTaskTags` into `src/lib/server/actions/string-parsers.ts`, backed by a zod `safeParse`, replacing the file-local `parseStoredTags` in `tasks/+page.server.ts` and the raw `JSON.parse` in `tasks/[id]/edit/+page.server.ts` so malformed stored tags fail safely (return `null`) everywhere instead of only in some code paths.

## Test plan
- [x] `npm run check` (svelte-check / TypeScript) — 0 errors
- [x] `npm run test` — 334 tests passing, including new unit tests for `buildWeatherJson` and `parseTaskTags`
- [x] `npm run fmt:check` — all files correctly formatted
- [x] `npm run lint` — no new issues (pre-existing unrelated `fallow dead-code` warnings confirmed present on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)