### PR TITLE
Reuse APP_TIME_ZONE constant in email notifications

### DIFF
--- a/src/lib/server/email/email-notifications.ts
+++ b/src/lib/server/email/email-notifications.ts
@@ -13,7 +13,7 @@
 
 import { logger } from '$lib';
 import { getVisitStatusThresholdsByUserIds } from '$lib/server/visit-status-settings';
-import { getTodayString } from '$lib/utils/date';
+import { APP_TIME_ZONE, getTodayString } from '$lib/utils/date';
 import { getWorkoutNotificationTag } from '$lib/utils/workout';
 import { and, eq, sql } from 'drizzle-orm';
 
@@ -818,7 +818,7 @@ export async function runEmailNotifications(): Promise<{ ok: true } | { ok: fals
 
 	// Convert UTC time to PST/PDT (automatically handles DST)
 	const pstFormatter = new Intl.DateTimeFormat('en-US', {
-		timeZone: 'America/Los_Angeles',
+		timeZone: APP_TIME_ZONE,
 		hour: '2-digit',
 		hour12: false,
 		minute: '2-digit'
@@ -830,7 +830,7 @@ export async function runEmailNotifications(): Promise<{ ok: true } | { ok: fals
 
 	// Get day of week in PST (important for weekly reminders)
 	const pstDayFormatter = new Intl.DateTimeFormat('en-US', {
-		timeZone: 'America/Los_Angeles',
+		timeZone: APP_TIME_ZONE,
 		weekday: 'short'
 	});
 	const pstDayStr = pstDayFormatter.format(now);

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -8,7 +8,7 @@
  * These utilities ensure dates are parsed and displayed in the local timezone.
  */
 
-const APP_TIME_ZONE = 'America/Los_Angeles';
+export const APP_TIME_ZONE = 'America/Los_Angeles';
 
 const appDateFormatter = new Intl.DateTimeFormat('en-US', {
 	timeZone: APP_TIME_ZONE,


### PR DESCRIPTION
## Summary
- Exports `APP_TIME_ZONE` from `$lib/utils/date.ts` instead of keeping it as a file-local constant.
- Replaces the two hardcoded `'America/Los_Angeles'` strings in `$lib/server/email/email-notifications.ts` with the shared import.

## Related
Closes #252

## Test plan
- [x] `npm run test` — all 334 tests pass
- [x] `npm run lint` / type check clean (via pre-commit hooks)