### PR TITLE
Replace raw weather JSON.parse in journal detail load

### DIFF
--- a/src/routes/(app)/journal/[id]/+page.server.ts
+++ b/src/routes/(app)/journal/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import { getUser, requireAuth } from '$lib/server/actions/auth-guard';
 import { getDb } from '$lib/server/db';
 import { journalEntries } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
+import { safeParse } from '$lib/utils';
 import { error, fail, redirect } from '@sveltejs/kit';
 import { and, eq } from 'drizzle-orm';
 import { superValidate } from 'sveltekit-superforms';
@@ -20,7 +21,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		throw error(404, 'Entry not found');
 	}
 
-	const weather = entry.weather ? JSON.parse(entry.weather) : null;
+	const weather = safeParse<{ temp?: number; condition?: string } | null>(entry.weather, null);
 
 	const form = await superValidate(
 		{


### PR DESCRIPTION
## Summary
- Replaces the raw `JSON.parse(entry.weather)` in the journal detail page load with the existing `safeParse` utility and a typed fallback (`null`), so invalid stored JSON no longer crashes the load with an unhandled exception.

## Related
Closes #254

## Test plan
- [x] `npm run test` — all 334 tests pass
- [x] `npm run lint` / type check clean (via pre-commit hooks)