### PR TITLE
Remove dead params.id guards in visits [id] route

### DIFF
--- a/src/routes/(app)/visits/[id]/+page.server.ts
+++ b/src/routes/(app)/visits/[id]/+page.server.ts
@@ -21,10 +21,6 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, params }) => {
-	if (!params.id) {
-		throw error(400, 'Person ID is required');
-	}
-
 	const db = getDb();
 	const userId = getUser(locals).id;
 
@@ -89,10 +85,6 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
 export const actions: Actions = {
 	logVisit: requireAuth(async ({ request, params }, user) => {
-		if (!params.id) {
-			return fail(400, { error: 'Person ID is required' });
-		}
-
 		const form = await superValidate(request, zod4(visitSchema));
 
 		if (!form.valid) {
@@ -152,10 +144,6 @@ export const actions: Actions = {
 	}),
 
 	updateVisit: requireAuth(async ({ request, params }, user) => {
-		if (!params.id) {
-			return fail(400, { error: 'Person ID is required' });
-		}
-
 		const formData = await request.formData();
 		const visitId = formData.get('visitId');
 		const form = await superValidate(formData, zod4(visitSchema));
@@ -224,10 +212,6 @@ export const actions: Actions = {
 	}),
 
 	updatePerson: requireAuth(async ({ request, params }, user) => {
-		if (!params.id) {
-			return fail(400, { error: 'Person ID is required' });
-		}
-
 		const form = await superValidate(request, zod4(personSchema));
 
 		if (!form.valid) {
@@ -276,10 +260,6 @@ export const actions: Actions = {
 	}),
 
 	archivePerson: requireAuth(async ({ params }, user) => {
-		if (!params.id) {
-			return fail(400, { error: 'Person ID is required' });
-		}
-
 		try {
 			const db = getDb();
 
@@ -310,10 +290,6 @@ export const actions: Actions = {
 	}),
 
 	deletePerson: requireAuth(async ({ params }, user) => {
-		if (!params.id) {
-			return fail(400, { error: 'Person ID is required' });
-		}
-
 		try {
 			const db = getDb();
 


### PR DESCRIPTION
## Summary
- Removed six unreachable `if (!params.id) { ... }` guards in `src/routes/(app)/visits/[id]/+page.server.ts` — SvelteKit guarantees `params.id` is a non-empty string for a `[id]` route segment, so these branches could never execute
- `params.id` is now used directly throughout the load function and action handlers

## Test plan
- [x] `npm run check` — 0 errors
- [x] Verified `error` and `fail` imports still used elsewhere in the file

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)