### PR TITLE
Remove redundant string casts in journal update action

### DIFF
--- a/src/routes/(app)/journal/[id]/+page.server.ts
+++ b/src/routes/(app)/journal/[id]/+page.server.ts
@@ -56,8 +56,8 @@ export const actions: Actions = {
 			await db
 				.update(journalEntries)
 				.set({
-					date: form.data.date as string,
-					content: form.data.content as string,
+					date: form.data.date,
+					content: form.data.content,
 					location,
 					weather,
 					...withAuditFieldsForUpdate()


### PR DESCRIPTION
## Summary
- Removed the `as string` casts on `form.data.date` and `form.data.content` in the journal `update` action
- `journalEntrySchema` defines both fields as non-optional `z.string()`, so `superValidate` already types them as `string` — the casts were redundant and could have masked a future schema/type mismatch

## Test plan
- [x] `npm run check` — 0 errors (confirms the casts weren't needed)

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)