### PR TITLE
Remove redundant dashboard auth branch

### DIFF
--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -1,4 +1,5 @@
 import { logger } from '$lib';
+import { getUser } from '$lib/server/actions/auth-guard';
 import { getDb } from '$lib/server/db';
 import {
 	dailyAgendaEntries,
@@ -532,8 +533,7 @@ function emptyDashboardReturn() {
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const user = locals.user;
-	if (!user) return emptyDashboardReturn();
+	const user = getUser(locals);
 
 	const today = getTodayString();
 	const ranges = buildDateRanges(today);


### PR DESCRIPTION
## Summary
- `(app)/+layout.server.ts` already redirects unauthenticated users to `/sign-in` before `dashboard/+page.server.ts`'s `load` runs, so `if (!user) return emptyDashboardReturn()` was unreachable dead code
- Switched to `getUser(locals)` for type-narrowed, consistent auth access (matches other app routes)
- Kept `emptyDashboardReturn()` as the catch-block fallback for query failures — that's its real purpose

## Test plan
- [x] `npm run check` — 0 errors

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)