### PR TITLE
Standardize logger.error call signatures

### DIFF
--- a/src/lib/server/actions/meditation-session-actions.ts
+++ b/src/lib/server/actions/meditation-session-actions.ts
@@ -41,7 +41,7 @@ export async function handleUpdateSession(request: Request, userId: string) {
 		logger.info('Meditation session updated', { sessionId: form.data.id, userId });
 		return message(form, { type: 'success', text: 'Session updated successfully!' });
 	} catch (err) {
-		logger.error('Failed to update session', { error: err });
+		logger.error('Failed to update session', err);
 		return message(
 			form,
 			{ type: 'error', text: 'An error occurred while updating the session.' },
@@ -68,7 +68,7 @@ export async function handleDeleteSession(request: Request, userId: string) {
 		logger.info('Meditation session deleted', { sessionId, userId });
 		return { success: true };
 	} catch (err) {
-		logger.error('Failed to delete session', { error: err });
+		logger.error('Failed to delete session', err);
 		return fail(500, { error: 'Failed to delete session' });
 	}
 }

--- a/src/lib/server/email/email-notifications.ts
+++ b/src/lib/server/email/email-notifications.ts
@@ -237,7 +237,7 @@ async function processWorkoutReminders(
 			sentCount++;
 			logger.debug(`   ✅ Sent successfully`);
 		} catch (error) {
-			logger.error(`   ❌ Failed to send:`, { error });
+			logger.error(`   ❌ Failed to send:`, error);
 		}
 	}
 
@@ -326,7 +326,7 @@ async function processMeditationReminders(
 			sentCount++;
 			logger.debug(`   ✅ Sent successfully`);
 		} catch (error) {
-			logger.error(`   ❌ Failed to send:`, { error });
+			logger.error(`   ❌ Failed to send:`, error);
 		}
 	}
 
@@ -451,7 +451,7 @@ async function processVisitWarnings(): Promise<void> {
 			sentCount++;
 			logger.debug(`   ✅ Sent successfully`);
 		} catch (error) {
-			logger.error(`   ❌ Failed to send:`, { error });
+			logger.error(`   ❌ Failed to send:`, error);
 		}
 	}
 
@@ -583,10 +583,7 @@ async function processDailyAgendaDigests(
 			sentCount++;
 			logger.debug('   ✅ Sent successfully');
 		} catch (error) {
-			logger.error('   ❌ Failed to send daily agenda digest', {
-				error,
-				userId: userData.id
-			});
+			logger.error('   ❌ Failed to send daily agenda digest', error, { userId: userData.id });
 		}
 	}
 
@@ -650,10 +647,7 @@ async function processTasksDueTodayDigests(
 			sentCount++;
 			logger.debug('   ✅ Sent successfully');
 		} catch (error) {
-			logger.error('   ❌ Failed to send Tasks due-today digest', {
-				error,
-				userId: userData.id
-			});
+			logger.error('   ❌ Failed to send Tasks due-today digest', error, { userId: userData.id });
 		}
 	}
 
@@ -719,7 +713,7 @@ async function processVisitsTodayReminders(todayPacific: string): Promise<void> 
 			sentCount++;
 			logger.debug(`   ✅ Sent successfully`);
 		} catch (error) {
-			logger.error(`   ❌ Failed to send:`, { error });
+			logger.error(`   ❌ Failed to send:`, error);
 		}
 	}
 
@@ -799,7 +793,7 @@ async function processScheduledVisitReminders(): Promise<void> {
 			sentCount++;
 			logger.debug(`   ✅ Sent successfully`);
 		} catch (error) {
-			logger.error(`   ❌ Failed to send:`, { error });
+			logger.error(`   ❌ Failed to send:`, error);
 		}
 	}
 
@@ -862,7 +856,7 @@ export async function runEmailNotifications(): Promise<{ ok: true } | { ok: fals
 		logger.debug('\n✅ Email notifications cron job completed successfully!');
 		return { ok: true };
 	} catch (error) {
-		logger.error('\n❌ Email notifications cron job failed:', { error });
+		logger.error('\n❌ Email notifications cron job failed:', error);
 		return { ok: false, error: error instanceof Error ? error : new Error('Unknown error') };
 	}
 }

--- a/src/lib/server/email/index.ts
+++ b/src/lib/server/email/index.ts
@@ -181,7 +181,7 @@ export async function sendWorkoutReminderEmail(
 			`
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send workout reminder email:', { error });
+		logger.error('❌ Failed to send workout reminder email:', error);
 		throw error;
 	}
 }
@@ -236,7 +236,7 @@ export async function sendMeditationReminderEmail(
 			`
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send meditation reminder email:', { error });
+		logger.error('❌ Failed to send meditation reminder email:', error);
 		throw error;
 	}
 }
@@ -304,7 +304,7 @@ export async function sendVisitWarningEmail(
 			`
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send visit warning email:', { error });
+		logger.error('❌ Failed to send visit warning email:', error);
 		throw error;
 	}
 }
@@ -326,7 +326,7 @@ export async function sendTasksDueTodayEmail(
 			html: buildTasksDueTodayEmailHtml(name, tasks, dateString)
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send Tasks Due Today email:', { error });
+		logger.error('❌ Failed to send Tasks Due Today email:', error);
 		throw error;
 	}
 }
@@ -386,7 +386,7 @@ export async function sendScheduledVisitReminderEmail(
 			`
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send scheduled visit reminder email:', { error });
+		logger.error('❌ Failed to send scheduled visit reminder email:', error);
 		throw error;
 	}
 }
@@ -443,7 +443,7 @@ export async function sendVisitTodayReminderEmail(
 			`
 		});
 	} catch (error) {
-		logger.error('❌ Failed to send visit today reminder email:', { error });
+		logger.error('❌ Failed to send visit today reminder email:', error);
 		throw error;
 	}
 }

--- a/src/lib/utils/journal-context.ts
+++ b/src/lib/utils/journal-context.ts
@@ -67,7 +67,7 @@ export async function getCurrentWeather(): Promise<JournalWeather> {
 			condition
 		};
 	} catch (error) {
-		logger.error('Failed to get weather', { error: JSON.stringify(error) });
+		logger.error('Failed to get weather', error);
 		throw new TypeError('Unable to retrieve your location for weather information.');
 	}
 }

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -600,7 +600,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 			todayAgendaSummary: buildTodayAgendaSummary(data.agendaEntriesForTrend, today)
 		};
 	} catch (error) {
-		logger.error('Failed to load dashboard data', { error });
+		logger.error('Failed to load dashboard data', error);
 		return emptyDashboardReturn();
 	}
 };

--- a/src/routes/(app)/fitness/+page.server.ts
+++ b/src/routes/(app)/fitness/+page.server.ts
@@ -135,7 +135,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			reminderForm
 		};
 	} catch (error) {
-		logger.error('Failed to load fitness data', { error });
+		logger.error('Failed to load fitness data', error);
 		return {
 			tab,
 			reminders: [],
@@ -184,7 +184,7 @@ export const actions: Actions = {
 
 			logger.info('Weight entry logged', { entryId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to log weight entry', { error });
+			logger.error('Failed to log weight entry', error);
 			return message(
 				form,
 				{
@@ -236,7 +236,7 @@ export const actions: Actions = {
 
 			logger.info('Goal weight set', { userId: user.id });
 		} catch (error) {
-			logger.error('Failed to set goal weight', { error });
+			logger.error('Failed to set goal weight', error);
 			return message(
 				form,
 				{
@@ -304,7 +304,7 @@ export const actions: Actions = {
 
 			logger.info('Workout logged', { workoutId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to log workout', { error });
+			logger.error('Failed to log workout', error);
 			return message(
 				form,
 				{
@@ -343,7 +343,7 @@ export const actions: Actions = {
 
 			logger.info('Meal logged', { mealId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to log meal', { error });
+			logger.error('Failed to log meal', error);
 			return message(
 				form,
 				{
@@ -395,7 +395,7 @@ export const actions: Actions = {
 
 			logger.info('Calorie target set', { userId: user.id });
 		} catch (error) {
-			logger.error('Failed to set calorie target', { error });
+			logger.error('Failed to set calorie target', error);
 			return message(
 				form,
 				{
@@ -434,7 +434,7 @@ export const actions: Actions = {
 
 			logger.info('Workout reminder created', { reminderId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to create workout reminder', { error });
+			logger.error('Failed to create workout reminder', error);
 			return message(
 				form,
 				{
@@ -487,7 +487,7 @@ export const actions: Actions = {
 				userId: user.id
 			});
 		} catch (error) {
-			logger.error('Failed to update workout reminder', { error });
+			logger.error('Failed to update workout reminder', error);
 			return message(
 				form,
 				{
@@ -522,7 +522,7 @@ export const actions: Actions = {
 
 			logger.info('Workout reminder deleted', { reminderId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete workout reminder', { error, reminderId: form.data.id });
+			logger.error('Failed to delete workout reminder', error, { reminderId: form.data.id });
 			return message(
 				form,
 				{
@@ -565,7 +565,7 @@ export const actions: Actions = {
 
 			logger.info('Weight entry updated', { entryId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to update weight entry', { error });
+			logger.error('Failed to update weight entry', error);
 			return message(
 				form,
 				{ type: 'error', text: 'Failed to update weight entry. Please try again.' },
@@ -599,7 +599,7 @@ export const actions: Actions = {
 
 			logger.info('Weight entry deleted', { entryId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete weight entry', { error });
+			logger.error('Failed to delete weight entry', error);
 			return fail(500, { error: 'Failed to delete weight entry' });
 		}
 
@@ -672,7 +672,7 @@ export const actions: Actions = {
 
 			logger.info('Workout updated', { workoutId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to update workout', { error });
+			logger.error('Failed to update workout', error);
 			return message(
 				form,
 				{ type: 'error', text: 'Failed to update workout. Please try again.' },
@@ -706,7 +706,7 @@ export const actions: Actions = {
 
 			logger.info('Workout deleted', { workoutId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete workout', { error });
+			logger.error('Failed to delete workout', error);
 			return fail(500, { error: 'Failed to delete workout' });
 		}
 
@@ -743,7 +743,7 @@ export const actions: Actions = {
 
 			logger.info('Meal updated', { mealId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to update meal', { error });
+			logger.error('Failed to update meal', error);
 			return message(
 				form,
 				{ type: 'error', text: 'Failed to update meal. Please try again.' },
@@ -777,7 +777,7 @@ export const actions: Actions = {
 
 			logger.info('Meal deleted', { mealId: form.data.id, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete meal', { error });
+			logger.error('Failed to delete meal', error);
 			return fail(500, { error: 'Failed to delete meal' });
 		}
 

--- a/src/routes/(app)/journal/+page.server.ts
+++ b/src/routes/(app)/journal/+page.server.ts
@@ -16,7 +16,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	});
 
 	if (!filters.success) {
-		logger.error('Invalid filter parameters', { error: filters.error });
+		logger.error('Invalid filter parameters', filters.error);
 		return {
 			entries: [],
 			filters: { content: '', date: '' }
@@ -55,7 +55,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			}
 		};
 	} catch (error) {
-		logger.error('Failed to load journal entries', { error });
+		logger.error('Failed to load journal entries', error);
 		return {
 			entries: [],
 			filters: {

--- a/src/routes/(app)/journal/[id]/+page.server.ts
+++ b/src/routes/(app)/journal/[id]/+page.server.ts
@@ -66,7 +66,7 @@ export const actions: Actions = {
 
 			logger.info('Journal entry updated', { entryId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to update journal entry', { error });
+			logger.error('Failed to update journal entry', error);
 			return fail(500, { form, error: 'Failed to update journal entry' });
 		}
 
@@ -97,7 +97,7 @@ export const actions: Actions = {
 
 			logger.info('Journal entry deleted', { entryId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete journal entry', { error, entryId });
+			logger.error('Failed to delete journal entry', error, { entryId });
 			return fail(500, { error: 'Failed to delete journal entry' });
 		}
 

--- a/src/routes/(app)/journal/new/+page.server.ts
+++ b/src/routes/(app)/journal/new/+page.server.ts
@@ -50,7 +50,7 @@ export const actions: Actions = {
 
 			logger.info('Journal entry created', { entryId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to create journal entry', { error, userId: user.id });
+			logger.error('Failed to create journal entry', error, { userId: user.id });
 			return message(
 				form,
 				{

--- a/src/routes/(app)/meditation/+page.server.ts
+++ b/src/routes/(app)/meditation/+page.server.ts
@@ -28,7 +28,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	});
 
 	if (!filters.success) {
-		logger.error('Invalid filter parameters', { error: filters.error });
+		logger.error('Invalid filter parameters', filters.error);
 		return {
 			routines: [],
 			schedules: [],
@@ -112,7 +112,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			editSessionForm
 		};
 	} catch (error) {
-		logger.error('Failed to load meditation data', { error });
+		logger.error('Failed to load meditation data', error);
 		return {
 			routines: [],
 			schedules: [],

--- a/src/routes/(app)/meditation/routines/[id]/+page.server.ts
+++ b/src/routes/(app)/meditation/routines/[id]/+page.server.ts
@@ -120,7 +120,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		if (isHttpError(err) || isRedirect(err)) {
 			throw err;
 		}
-		logger.error('Failed to load meditation routine', { error: err });
+		logger.error('Failed to load meditation routine', err);
 		throw error(500, 'Failed to load routine');
 	}
 };
@@ -203,7 +203,7 @@ export const actions: Actions = {
 				text: 'Schedule saved successfully!'
 			});
 		} catch (error) {
-			logger.error('Failed to create/update schedule', { error });
+			logger.error('Failed to create/update schedule', error);
 			return message(
 				form,
 				{
@@ -238,7 +238,7 @@ export const actions: Actions = {
 			});
 			return { success: true };
 		} catch (error) {
-			logger.error('Failed to delete schedule', { error });
+			logger.error('Failed to delete schedule', error);
 			return fail(500, { error: 'Failed to delete schedule' });
 		}
 	}),
@@ -277,7 +277,7 @@ export const actions: Actions = {
 				text: 'Session logged successfully!'
 			});
 		} catch (error) {
-			logger.error('Failed to complete session', { error });
+			logger.error('Failed to complete session', error);
 			return message(
 				form,
 				{
@@ -338,7 +338,7 @@ export const actions: Actions = {
 				text: 'Routine updated successfully!'
 			});
 		} catch (error) {
-			logger.error('Failed to update routine', { error });
+			logger.error('Failed to update routine', error);
 			return message(
 				form,
 				{
@@ -388,7 +388,7 @@ export const actions: Actions = {
 				userId: user.id
 			});
 		} catch (error) {
-			logger.error('Failed to delete routine', { error });
+			logger.error('Failed to delete routine', error);
 			return fail(500, { error: 'Failed to delete routine' });
 		}
 

--- a/src/routes/(app)/meditation/routines/new/+page.server.ts
+++ b/src/routes/(app)/meditation/routines/new/+page.server.ts
@@ -63,7 +63,7 @@ export const actions: Actions = {
 
 			logger.info('Meditation routine created', { routineId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to create meditation routine', { error });
+			logger.error('Failed to create meditation routine', error);
 			return message(
 				form,
 				{

--- a/src/routes/(app)/tasks/+page.server.ts
+++ b/src/routes/(app)/tasks/+page.server.ts
@@ -471,7 +471,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	};
 
 	if (!filters.success) {
-		logger.error('Invalid task filter parameters', { error: filters.error, userId });
+		logger.error('Invalid task filter parameters', filters.error, { userId });
 
 		return {
 			activeTab,
@@ -633,7 +633,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			}
 		};
 	} catch (error) {
-		logger.error('Failed to load tasks', { error, userId });
+		logger.error('Failed to load tasks', error, { userId });
 		return {
 			activeTab,
 			agenda,
@@ -743,7 +743,7 @@ export const actions: Actions = {
 				userId: user.id
 			});
 		} catch (error) {
-			logger.error('Failed to delete task from board', { error, form });
+			logger.error('Failed to delete task from board', error, { form });
 			return fail(500, { form, error: 'Failed to delete task' });
 		}
 
@@ -968,7 +968,7 @@ export const actions: Actions = {
 			logger.info('Mood log created', { moodLogId, userId: user.id });
 			return message(form, { type: 'success', text: "Today's mood was logged." });
 		} catch (error) {
-			logger.error('Failed to upsert mood log', { error, userId: user.id });
+			logger.error('Failed to upsert mood log', error, { userId: user.id });
 			return message(
 				form,
 				{ type: 'error', text: 'Failed to save your mood. Please try again.' },

--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -173,7 +173,7 @@ export const actions: Actions = {
 
 			logger.info('Task updated', { taskId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to update task', { error, taskId });
+			logger.error('Failed to update task', error, { taskId });
 			return fail(500, { form, error: 'Failed to update task' });
 		}
 
@@ -205,7 +205,7 @@ export const actions: Actions = {
 
 			logger.info('Task deleted', { taskId, taskNumber: existing.taskNumber, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to delete task', { error, taskId });
+			logger.error('Failed to delete task', error, { taskId });
 			return fail(500, { error: 'Failed to delete task' });
 		}
 

--- a/src/routes/(app)/tasks/new/+page.server.ts
+++ b/src/routes/(app)/tasks/new/+page.server.ts
@@ -135,7 +135,7 @@ export const actions: Actions = {
 				userId: user.id
 			});
 		} catch (error) {
-			logger.error('Failed to create task', { error, userId: user.id });
+			logger.error('Failed to create task', error, { userId: user.id });
 			return message(
 				form,
 				{

--- a/src/routes/(app)/visits/+page.server.ts
+++ b/src/routes/(app)/visits/+page.server.ts
@@ -94,7 +94,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 		return { people: peopleWithStatus };
 	} catch (error) {
-		logger.error('Failed to load people', { error });
+		logger.error('Failed to load people', error);
 		return { people: [] };
 	}
 };

--- a/src/routes/(app)/visits/[id]/+page.server.ts
+++ b/src/routes/(app)/visits/[id]/+page.server.ts
@@ -78,7 +78,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		};
 	} catch (err) {
 		if (isHttpError(err) || isRedirect(err)) throw err;
-		logger.error('Failed to load visit page data', { error: err, personId: params.id, userId });
+		logger.error('Failed to load visit page data', err, { personId: params.id, userId });
 		throw error(500, 'Failed to load page data');
 	}
 };
@@ -131,7 +131,7 @@ export const actions: Actions = {
 				text: 'Visit logged successfully!'
 			});
 		} catch (err) {
-			logger.error('Failed to log visit', { error: err });
+			logger.error('Failed to log visit', err);
 			return message(
 				form,
 				{
@@ -199,7 +199,7 @@ export const actions: Actions = {
 				text: 'Visit updated successfully!'
 			});
 		} catch (err) {
-			logger.error('Failed to update visit', { error: err });
+			logger.error('Failed to update visit', err);
 			return message(
 				form,
 				{
@@ -247,7 +247,7 @@ export const actions: Actions = {
 				text: 'Person updated successfully!'
 			});
 		} catch (err) {
-			logger.error('Failed to update person', { error: err });
+			logger.error('Failed to update person', err);
 			return message(
 				form,
 				{
@@ -282,7 +282,7 @@ export const actions: Actions = {
 
 			logger.info('Person archived', { personId: params.id, userId: user.id });
 		} catch (err) {
-			logger.error('Failed to archive person', { error: err });
+			logger.error('Failed to archive person', err);
 			return fail(500, { error: 'Failed to archive person' });
 		}
 
@@ -307,7 +307,7 @@ export const actions: Actions = {
 
 			logger.info('Person deleted', { personId: params.id, userId: user.id });
 		} catch (err) {
-			logger.error('Failed to delete person', { error: err });
+			logger.error('Failed to delete person', err);
 			return fail(500, { error: 'Failed to delete person' });
 		}
 
@@ -340,7 +340,7 @@ export const actions: Actions = {
 
 			return { success: true };
 		} catch (err) {
-			logger.error('Failed to delete visit', { error: err });
+			logger.error('Failed to delete visit', err);
 			return fail(500, { error: 'Failed to delete visit' });
 		}
 	})

--- a/src/routes/(app)/visits/people/new/+page.server.ts
+++ b/src/routes/(app)/visits/people/new/+page.server.ts
@@ -40,7 +40,7 @@ export const actions: Actions = {
 
 			logger.info('Person created', { personId, userId: user.id });
 		} catch (error) {
-			logger.error('Failed to create person', { error });
+			logger.error('Failed to create person', error);
 			return message(
 				form,
 				{

--- a/src/routes/api/cron/email-notifications/+server.ts
+++ b/src/routes/api/cron/email-notifications/+server.ts
@@ -31,7 +31,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		logger.info('✅ Email notifications job completed successfully!');
 		return json({ success: true, timestamp: new Date().toISOString() });
 	} catch (error) {
-		logger.error('❌ Email notifications job failed:', { error });
+		logger.error('❌ Email notifications job failed:', error);
 		return json({ error: 'Job failed' }, { status: 500 });
 	}
 };


### PR DESCRIPTION
## Summary
- Replace `logger.error(message, { error })` with `logger.error(message, error, meta)` across ~65 call sites in server routes, actions, and email utilities
- Two `logger.warn` calls with a similarly-shaped object were intentionally left untouched since `warn`'s signature takes a meta object, not a raw error

## Why
`logger.error`'s second argument is checked with `instanceof Error` to build structured error output. Passing `{ error }` (a plain object) instead of the raw error skips that check and falls through to generic JSON serialization, producing a doubly-nested `error.error.*` key that breaks log queries expecting `error.message` at the top level.

Fixes #255

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — no new issues (pre-existing dead-export warning unrelated to this change)
- [x] `npm run fmt:check` — all files formatted
- [x] `npm run test` — 334 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)