### PR TITLE
Adopt satisfies Actions consistently

### DIFF
--- a/src/routes/(app)/fitness/+page.server.ts
+++ b/src/routes/(app)/fitness/+page.server.ts
@@ -160,7 +160,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	logWeight: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(logWeightSchema));
 

--- a/src/routes/(app)/journal/[id]/+page.server.ts
+++ b/src/routes/(app)/journal/[id]/+page.server.ts
@@ -37,7 +37,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	return { form, entry };
 };
 
-export const actions: Actions = {
+export const actions = {
 	update: requireAuth(async ({ request, params }, user) => {
 		const entryId = params.id;
 		const form = await superValidate(request, zod4(journalEntrySchema));
@@ -103,4 +103,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/journal');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/journal/new/+page.server.ts
+++ b/src/routes/(app)/journal/new/+page.server.ts
@@ -21,7 +21,7 @@ export const load: PageServerLoad = async () => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(journalEntrySchema));
 
@@ -63,4 +63,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/journal');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/meditation/+page.server.ts
+++ b/src/routes/(app)/meditation/+page.server.ts
@@ -122,7 +122,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	updateSession: requireAuth(async ({ request }, user) => handleUpdateSession(request, user.id)),
 
 	deleteSession: requireAuth(async ({ request }, user) => handleDeleteSession(request, user.id))

--- a/src/routes/(app)/meditation/routines/[id]/+page.server.ts
+++ b/src/routes/(app)/meditation/routines/[id]/+page.server.ts
@@ -125,7 +125,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	createSchedule: requireAuth(async ({ request, locals, params }, user) => {
 		const form = await superValidate(request, zod4(scheduleSchema));
 		const routineId = params.id;

--- a/src/routes/(app)/meditation/routines/new/+page.server.ts
+++ b/src/routes/(app)/meditation/routines/new/+page.server.ts
@@ -17,7 +17,7 @@ export const load: PageServerLoad = async () => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(createRoutineSchema));
 
@@ -76,4 +76,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/meditation');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/profile/+page.server.ts
+++ b/src/routes/(app)/profile/+page.server.ts
@@ -73,7 +73,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	update: requireAuth(async ({ request }, currentUser) => {
 		const form = await superValidate(request, zod4(updateProfileSchema));
 		if (!form.valid) {

--- a/src/routes/(app)/tasks/+page.server.ts
+++ b/src/routes/(app)/tasks/+page.server.ts
@@ -645,7 +645,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	moveBoardTask: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(moveTaskBoardSchema));
 		if (!form.valid) return fail(400, { form });
@@ -976,4 +976,4 @@ export const actions: Actions = {
 			);
 		}
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -78,7 +78,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	};
 };
 
-export const actions: Actions = {
+export const actions = {
 	update: requireAuth(async ({ request, params }, user) => {
 		const taskId = params.id;
 
@@ -211,4 +211,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/tasks');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/tasks/new/+page.server.ts
+++ b/src/routes/(app)/tasks/new/+page.server.ts
@@ -102,7 +102,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(createTaskSchema));
 
@@ -148,4 +148,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/tasks');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/visits/[id]/+page.server.ts
+++ b/src/routes/(app)/visits/[id]/+page.server.ts
@@ -83,7 +83,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	}
 };
 
-export const actions: Actions = {
+export const actions = {
 	logVisit: requireAuth(async ({ request, params }, user) => {
 		const form = await superValidate(request, zod4(visitSchema));
 
@@ -344,4 +344,4 @@ export const actions: Actions = {
 			return fail(500, { error: 'Failed to delete visit' });
 		}
 	})
-};
+} satisfies Actions;

--- a/src/routes/(app)/visits/people/new/+page.server.ts
+++ b/src/routes/(app)/visits/people/new/+page.server.ts
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async () => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: requireAuth(async ({ request }, user) => {
 		const form = await superValidate(request, zod4(personSchema));
 
@@ -53,4 +53,4 @@ export const actions: Actions = {
 
 		throw redirect(303, '/visits');
 	})
-};
+} satisfies Actions;

--- a/src/routes/(auth)/forgot-password/+page.server.ts
+++ b/src/routes/(auth)/forgot-password/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: async ({ request }) => {
 		const form = await superValidate(request, zod4(forgotPasswordSchema));
 

--- a/src/routes/(auth)/register/+page.server.ts
+++ b/src/routes/(auth)/register/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: async ({ request }) => {
 		const form = await superValidate(request, zod4(registerSchema));
 
@@ -50,4 +50,4 @@ export const actions: Actions = {
 			return message(form, { type: 'error', text: errorMessage }, { status: 400 });
 		}
 	}
-};
+} satisfies Actions;

--- a/src/routes/(auth)/reset-password/+page.server.ts
+++ b/src/routes/(auth)/reset-password/+page.server.ts
@@ -27,7 +27,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return { token, form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: async ({ request }) => {
 		const form = await superValidate(request, zod4(resetPasswordSchema));
 

--- a/src/routes/(auth)/sign-in/+page.server.ts
+++ b/src/routes/(auth)/sign-in/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return { form };
 };
 
-export const actions: Actions = {
+export const actions = {
 	default: async ({ request }) => {
 		const form = await superValidate(request, zod4(loginSchema));
 
@@ -47,4 +47,4 @@ export const actions: Actions = {
 			return message(form, errorMessage, { status: 400 });
 		}
 	}
-};
+} satisfies Actions;

--- a/src/routes/(auth)/sign-out/+page.server.ts
+++ b/src/routes/(auth)/sign-out/+page.server.ts
@@ -3,7 +3,7 @@ import { redirect } from '@sveltejs/kit';
 
 import type { Actions } from './$types';
 
-export const actions: Actions = {
+export const actions = {
 	default: async ({ request }) => {
 		await auth.api.signOut({
 			headers: request.headers


### PR DESCRIPTION
## Summary
- Migrate all 17 `+page.server.ts` action exports to `export const actions = { ... } satisfies Actions`
- Remove the redundant `: Actions` type annotation from the 7 files that already had `satisfies Actions` appended (having both defeats the purpose of `satisfies`, since the explicit annotation still widens the exported type)

## Why
`satisfies` validates the object literal against the `Actions` shape while keeping the narrower inferred type for each individual action handler, catching action-name typos and return-type mismatches that the widening `: Actions` annotation would silently allow.

Fixes #256

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — no new issues
- [x] `npm run fmt:check` — all files formatted
- [x] `npm run test` — 334 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)