### PR TITLE
Strengthen typing of buildTaskUpdateData

### DIFF
--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -24,8 +24,8 @@ import type { Actions, PageServerLoad } from './$types';
 function buildTaskUpdateData(
 	formData: UpdateTaskInput,
 	existingState: string
-): Record<string, unknown> {
-	const updateData: Record<string, unknown> = {
+): Partial<typeof tasks.$inferInsert> {
+	const updateData: Partial<typeof tasks.$inferInsert> = {
 		...withAuditFieldsForUpdate()
 	};
 


### PR DESCRIPTION
## Summary
- Type `buildTaskUpdateData`'s return value as `Partial<typeof tasks.$inferInsert>` instead of `Record<string, unknown>`

## Why
`Record<string, unknown>` discards Drizzle's column-level type checking on the update payload passed to `.set()`. A misspelled key (e.g. `updateData.duDate`) would type-check fine and silently be dropped at runtime. The Drizzle-inferred partial type catches that at compile time instead.

Fixes #260

## Test plan
- [x] `npm run check` — 0 errors (confirms all assigned fields match the tasks table's column types)
- [x] `npm run lint` — no new issues
- [x] `npm run fmt:check` — all files formatted
- [x] `npm run test` — 334 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)