### PR TITLE
Evaluate caching for visit status thresholds

### DIFF
--- a/src/lib/server/visit-status-settings.ts
+++ b/src/lib/server/visit-status-settings.ts
@@ -25,6 +25,14 @@ function toThresholds(
 	});
 }
 
+/**
+ * Caching evaluated and rejected (structure review follow-up #264): this is an indexed
+ * point lookup (`visitStatusSettings.userId` is unique) against the embedded, synchronous
+ * better-sqlite3 database, called at most once per page load across its call sites. It is
+ * already effectively as cheap as a read can be, so a TTL/session cache would add
+ * invalidation complexity without a measurable latency win. Revisit only if profiling shows
+ * otherwise or the lookup starts happening many times per request.
+ */
 export async function getVisitStatusThresholdsForUser(
 	userId: string,
 	db = getDb()


### PR DESCRIPTION
## Summary
- Assess whether TTL/session caching is warranted for `getVisitStatusThresholdsForUser`, per the structure review follow-up
- **Decision: no caching.** Record the reasoning as a doc comment on the function

## Why no caching
- `visitStatusSettings.userId` has a `.unique()` constraint, so this is an indexed point lookup
- The database is `better-sqlite3` — synchronous, in-process, no network round trip
- It's called at most once per page load across its 4 call sites (visits, visits/[id], dashboard, profile) — not repeatedly within a single request
- The underlying data only changes when a user submits the visit settings form, an infrequent write path

Given all of that, a TTL/session cache would add invalidation complexity (and cross-instance coherency concerns if the app ever runs multiple server instances) for a query that's already about as cheap as a database read gets. The single abstraction point in `visit-status-settings.ts` makes it easy to revisit if profiling ever shows otherwise.

Closes #264

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — no new issues
- [x] `npm run fmt:check` — all files formatted
- [x] `npm run test` — 334 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)