### PR TITLE
Allow scheduling a visit before any visit is logged

### DIFF
--- a/src/lib/schemas/visits.test.ts
+++ b/src/lib/schemas/visits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { personSchema, visitSchema } from './visits';
+import { personSchema, scheduleVisitSchema, visitSchema } from './visits';
 
 describe('personSchema', () => {
 	it('accepts a valid person with a name', () => {
@@ -82,5 +82,19 @@ describe('visitSchema', () => {
 	it('treats an empty string followUpDate as undefined (no follow-up)', () => {
 		const result = visitSchema.parse({ date: '2026-03-15', followUpDate: '' });
 		expect(result.followUpDate).toBeUndefined();
+	});
+});
+
+describe('scheduleVisitSchema', () => {
+	it('accepts a valid scheduled date', () => {
+		expect(() => scheduleVisitSchema.parse({ scheduledVisitDate: '2026-09-01' })).not.toThrow();
+	});
+
+	it('rejects an invalid date format', () => {
+		expect(scheduleVisitSchema.safeParse({ scheduledVisitDate: '09-01-2026' }).success).toBe(false);
+	});
+
+	it('rejects a missing scheduled date', () => {
+		expect(scheduleVisitSchema.safeParse({}).success).toBe(false);
 	});
 });

--- a/src/lib/schemas/visits.ts
+++ b/src/lib/schemas/visits.ts
@@ -29,6 +29,15 @@ export const personSchema = z.object({
 });
 
 /**
+ * Schema for scheduling a future visit for a person with no logged visits yet
+ */
+export const scheduleVisitSchema = z.object({
+	scheduledVisitDate: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)')
+});
+
+/**
  * Schema for creating and updating visits
  */
 export const visitSchema = z.object({

--- a/src/lib/server/db/migrations/0021_lonely_thing.sql
+++ b/src/lib/server/db/migrations/0021_lonely_thing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `people` ADD `scheduled_visit_date` text;

--- a/src/lib/server/db/migrations/meta/0021_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1972 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "891eea95-ecb5-4c8d-9b02-7c66ec214993",
+	"prevId": "942ea80f-fa95-47ab-86e1-af00f60c3944",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshTokenUpdatedAt": {
+					"name": "refreshTokenUpdatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_entries": {
+			"name": "daily_agenda_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"completed": {
+					"name": "completed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_entries_user_date_idx": {
+					"name": "daily_agenda_entries_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_group_date_idx": {
+					"name": "daily_agenda_entries_group_date_idx",
+					"columns": ["template_group_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_default_unique_idx": {
+					"name": "daily_agenda_entries_default_unique_idx",
+					"columns": ["user_id", "template_group_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_entries_user_id_user_id_fk": {
+					"name": "daily_agenda_entries_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"daily_agenda_entries_template_id_daily_agenda_templates_id_fk": {
+					"name": "daily_agenda_entries_template_id_daily_agenda_templates_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "daily_agenda_templates",
+					"columnsFrom": ["template_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_templates": {
+			"name": "daily_agenda_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[0,1,2,3,4,5,6]'"
+				},
+				"starts_on": {
+					"name": "starts_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ends_on": {
+					"name": "ends_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_templates_user_range_idx": {
+					"name": "daily_agenda_templates_user_range_idx",
+					"columns": ["user_id", "starts_on", "ends_on"],
+					"isUnique": false
+				},
+				"daily_agenda_templates_group_idx": {
+					"name": "daily_agenda_templates_group_idx",
+					"columns": ["template_group_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_templates_user_id_user_id_fk": {
+					"name": "daily_agenda_templates_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_templates",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_calorie_targets": {
+			"name": "daily_calorie_targets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_calories": {
+					"name": "target_calories",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_calorie_targets_user_id_unique": {
+					"name": "daily_calorie_targets_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_calorie_targets_user_id_user_id_fk": {
+					"name": "daily_calorie_targets_user_id_user_id_fk",
+					"tableFrom": "daily_calorie_targets",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_notifications": {
+			"name": "email_notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notification_type": {
+					"name": "notification_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_subject": {
+					"name": "email_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_notifications_userId_user_id_fk": {
+					"name": "email_notifications_userId_user_id_fk",
+					"tableFrom": "email_notifications",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"goal_weights": {
+			"name": "goal_weights",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_weight_lbs": {
+					"name": "target_weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"goal_weights_user_id_unique": {
+					"name": "goal_weights_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"goal_weights_user_id_user_id_fk": {
+					"name": "goal_weights_user_id_user_id_fk",
+					"tableFrom": "goal_weights",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"journal_entries": {
+			"name": "journal_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weather": {
+					"name": "weather",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"journal_entries_user_id_user_id_fk": {
+					"name": "journal_entries_user_id_user_id_fk",
+					"tableFrom": "journal_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meal_logs": {
+			"name": "meal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time_of_day": {
+					"name": "time_of_day",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"calories_estimate": {
+					"name": "calories_estimate",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meal_logs_user_id_user_id_fk": {
+					"name": "meal_logs_user_id_user_id_fk",
+					"tableFrom": "meal_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_routines": {
+			"name": "meditation_routines",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"link_url": {
+					"name": "link_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood_tags": {
+					"name": "mood_tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_predefined": {
+					"name": "is_predefined",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_routines_user_id_user_id_fk": {
+					"name": "meditation_routines_user_id_user_id_fk",
+					"tableFrom": "meditation_routines",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_schedules": {
+			"name": "meditation_schedules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_schedules_user_id_user_id_fk": {
+					"name": "meditation_schedules_user_id_user_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_schedules_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_schedules_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_sessions": {
+			"name": "meditation_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pre_mood_rating": {
+					"name": "pre_mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mood_rating": {
+					"name": "mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_sessions_user_id_user_id_fk": {
+					"name": "meditation_sessions_user_id_user_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_sessions_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_sessions_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mood_logs": {
+			"name": "mood_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood": {
+					"name": "mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"custom_mood": {
+					"name": "custom_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mood_logs_user_date_idx": {
+					"name": "mood_logs_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"mood_logs_user_date_unique_idx": {
+					"name": "mood_logs_user_date_unique_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"mood_logs_user_id_user_id_fk": {
+					"name": "mood_logs_user_id_user_id_fk",
+					"tableFrom": "mood_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"people": {
+			"name": "people",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_exempt": {
+					"name": "is_exempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"scheduled_visit_date": {
+					"name": "scheduled_visit_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"people_user_id_user_id_fk": {
+					"name": "people_user_id_user_id_fk",
+					"tableFrom": "people",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tasks": {
+			"name": "tasks",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"task_number": {
+					"name": "task_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_date": {
+					"name": "due_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'new'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tasks_task_number_unique": {
+					"name": "tasks_task_number_unique",
+					"columns": ["task_number"],
+					"isUnique": true
+				},
+				"tasks_user_state_sort_idx": {
+					"name": "tasks_user_state_sort_idx",
+					"columns": ["user_id", "state", "sort_order"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tasks_user_id_user_id_fk": {
+					"name": "tasks_user_id_user_id_fk",
+					"tableFrom": "tasks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visit_status_settings": {
+			"name": "visit_status_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recent_to_overdue_days": {
+					"name": "recent_to_overdue_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"overdue_to_critical_days": {
+					"name": "overdue_to_critical_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"visit_status_settings_user_id_unique": {
+					"name": "visit_status_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"visit_status_settings_user_id_user_id_fk": {
+					"name": "visit_status_settings_user_id_user_id_fk",
+					"tableFrom": "visit_status_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visits": {
+			"name": "visits",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"person_id": {
+					"name": "person_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"companions": {
+					"name": "companions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"follow_up_date": {
+					"name": "follow_up_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"visits_person_id_people_id_fk": {
+					"name": "visits_person_id_people_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "people",
+					"columnsFrom": ["person_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"visits_user_id_user_id_fk": {
+					"name": "visits_user_id_user_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"weight_entries": {
+			"name": "weight_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"weight_entries_user_id_user_id_fk": {
+					"name": "weight_entries_user_id_user_id_fk",
+					"tableFrom": "weight_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_exercises": {
+			"name": "workout_exercises",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_log_id": {
+					"name": "workout_log_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exercise_name": {
+					"name": "exercise_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sets": {
+					"name": "sets",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reps": {
+					"name": "reps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_exercises_workout_log_id_workout_logs_id_fk": {
+					"name": "workout_exercises_workout_log_id_workout_logs_id_fk",
+					"tableFrom": "workout_exercises",
+					"tableTo": "workout_logs",
+					"columnsFrom": ["workout_log_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_logs": {
+			"name": "workout_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"steps": {
+					"name": "steps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_logs_user_id_user_id_fk": {
+					"name": "workout_logs_user_id_user_id_fk",
+					"tableFrom": "workout_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_reminders": {
+			"name": "workout_reminders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_type": {
+					"name": "workout_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_reminders_user_id_user_id_fk": {
+					"name": "workout_reminders_user_id_user_id_fk",
+					"tableFrom": "workout_reminders",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1781652515212,
 			"tag": "0020_certain_leader",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "6",
+			"when": 1785649392677,
+			"tag": "0021_lonely_thing",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -618,6 +618,7 @@ export const people = sqliteTable('people', {
 	name: text('name').notNull(),
 	isExempt: integer('is_exempt', { mode: 'boolean' }).notNull().default(false),
 	isArchived: integer('is_archived', { mode: 'boolean' }).notNull().default(false),
+	scheduledVisitDate: text('scheduled_visit_date'),
 	createdAt: text('created_at')
 		.notNull()
 		.$defaultFn(() => new Date().toISOString()),

--- a/src/lib/server/email/email-notifications.ts
+++ b/src/lib/server/email/email-notifications.ts
@@ -48,8 +48,10 @@ import {
 } from './index';
 import {
 	buildScheduledVisitReminderEntityId,
+	buildScheduledVisitReminderEntityIdForPerson,
 	buildScheduledVisitReminderSubject,
 	buildVisitTodayReminderEntityId,
+	buildVisitTodayReminderEntityIdForPerson,
 	buildVisitTodayReminderSubject,
 	formatReminderDate,
 	getDateDaysAhead,
@@ -717,6 +719,58 @@ async function processVisitsTodayReminders(todayPacific: string): Promise<void> 
 		}
 	}
 
+	// Find all people (with no logged visits yet) scheduled for today
+	const todayScheduledOnly = db
+		.select({
+			person: people,
+			user: user
+		})
+		.from(people)
+		.innerJoin(user, eq(people.userId, user.id))
+		.where(and(eq(people.scheduledVisitDate, todayPacific), eq(people.isArchived, false)))
+		.all();
+
+	logger.debug(`   Found ${todayScheduledOnly.length} scheduled-only visits for today`);
+
+	for (const { person, user: userData } of todayScheduledOnly) {
+		if (person.isExempt) {
+			logger.debug(`   ⏭️  Skipping exempt person ${person.name}`);
+			continue;
+		}
+
+		const entityId = buildVisitTodayReminderEntityIdForPerson(person.id);
+
+		if (await alreadySentToday(userData.id, VISIT_TODAY_REMINDER_NOTIFICATION_TYPE, entityId)) {
+			logger.debug(`   ⏭️  Already sent today reminder for ${person.name} today`);
+			continue;
+		}
+
+		const formattedDate = formatReminderDate(todayPacific);
+		const subject = buildVisitTodayReminderSubject(person.name);
+
+		logger.debug(
+			`   📧 Sending visit-today reminder to ${userData.email} (${person.name} on ${todayPacific})`
+		);
+
+		try {
+			await sendVisitTodayReminderEmail(userData.email, userData.name, person.name, formattedDate);
+
+			await sendReminderNotification(
+				`You have a visit with ${person.name} today, ${formattedDate}.`,
+				'Synapse - Visit Today',
+				'busts_in_silhouette',
+				3
+			);
+
+			await logNotification(userData.id, VISIT_TODAY_REMINDER_NOTIFICATION_TYPE, entityId, subject);
+
+			sentCount++;
+			logger.debug(`   ✅ Sent successfully`);
+		} catch (error) {
+			logger.error(`   ❌ Failed to send:`, error);
+		}
+	}
+
 	logger.debug(`   📊 Sent ${sentCount} visit-today reminders`);
 }
 
@@ -756,6 +810,69 @@ async function processScheduledVisitReminders(): Promise<void> {
 		const entityId = buildScheduledVisitReminderEntityId(visit.id);
 
 		// Check if we already sent a reminder for this visit
+		if (await alreadySentToday(userData.id, SCHEDULED_VISIT_REMINDER_NOTIFICATION_TYPE, entityId)) {
+			logger.debug(`   ⏭️  Already sent reminder for ${person.name} today`);
+			continue;
+		}
+
+		const formattedFollowUpDate = formatReminderDate(oneWeekFromNow);
+		const subject = buildScheduledVisitReminderSubject(person.name);
+
+		logger.debug(
+			`   📧 Sending scheduled visit reminder to ${userData.email} (${person.name} on ${oneWeekFromNow})`
+		);
+
+		try {
+			await sendScheduledVisitReminderEmail(
+				userData.email,
+				userData.name,
+				person.name,
+				formattedFollowUpDate
+			);
+
+			await sendReminderNotification(
+				`Upcoming visit with ${person.name} is scheduled for ${formattedFollowUpDate}.`,
+				'Synapse - Upcoming Visit',
+				'calendar',
+				3
+			);
+
+			await logNotification(
+				userData.id,
+				SCHEDULED_VISIT_REMINDER_NOTIFICATION_TYPE,
+				entityId,
+				subject
+			);
+
+			sentCount++;
+			logger.debug(`   ✅ Sent successfully`);
+		} catch (error) {
+			logger.error(`   ❌ Failed to send:`, error);
+		}
+	}
+
+	// Find all people (with no logged visits yet) scheduled for exactly one week from today
+	const upcomingScheduledOnly = db
+		.select({
+			person: people,
+			user: user
+		})
+		.from(people)
+		.innerJoin(user, eq(people.userId, user.id))
+		.where(and(eq(people.scheduledVisitDate, oneWeekFromNow), eq(people.isArchived, false)))
+		.all();
+
+	logger.debug(`   Found ${upcomingScheduledOnly.length} scheduled-only visits in one week`);
+
+	for (const { person, user: userData } of upcomingScheduledOnly) {
+		if (person.isExempt) {
+			logger.debug(`   ⏭️  Skipping exempt person ${person.name}`);
+			continue;
+		}
+
+		const entityId = buildScheduledVisitReminderEntityIdForPerson(person.id);
+
+		// Check if we already sent a reminder for this person
 		if (await alreadySentToday(userData.id, SCHEDULED_VISIT_REMINDER_NOTIFICATION_TYPE, entityId)) {
 			logger.debug(`   ⏭️  Already sent reminder for ${person.name} today`);
 			continue;

--- a/src/lib/server/email/scheduled-visit-reminder-utils.test.ts
+++ b/src/lib/server/email/scheduled-visit-reminder-utils.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	buildScheduledVisitReminderEntityId,
+	buildScheduledVisitReminderEntityIdForPerson,
 	buildScheduledVisitReminderSubject,
+	buildVisitTodayReminderEntityId,
+	buildVisitTodayReminderEntityIdForPerson,
 	formatReminderDate,
 	getDateDaysAhead
 } from './scheduled-visit-reminder-utils';
@@ -44,6 +47,36 @@ describe('buildScheduledVisitReminderEntityId', () => {
 	it('prefixes the visit id with the reminder namespace', () => {
 		expect(buildScheduledVisitReminderEntityId('visit_abc123')).toBe(
 			'scheduled_visit:visit_abc123'
+		);
+	});
+});
+
+describe('buildScheduledVisitReminderEntityIdForPerson', () => {
+	it('prefixes the person id with a distinct namespace from the visit-based id', () => {
+		expect(buildScheduledVisitReminderEntityIdForPerson('person_abc123')).toBe(
+			'scheduled_visit:person:person_abc123'
+		);
+	});
+
+	it('never collides with a visit-based entity id sharing the same raw id', () => {
+		const sharedId = 'shared_id_123';
+		expect(buildScheduledVisitReminderEntityIdForPerson(sharedId)).not.toBe(
+			buildScheduledVisitReminderEntityId(sharedId)
+		);
+	});
+});
+
+describe('buildVisitTodayReminderEntityIdForPerson', () => {
+	it('prefixes the person id with a distinct namespace from the visit-based id', () => {
+		expect(buildVisitTodayReminderEntityIdForPerson('person_abc123')).toBe(
+			'visit_today:person:person_abc123'
+		);
+	});
+
+	it('never collides with a visit-based entity id sharing the same raw id', () => {
+		const sharedId = 'shared_id_123';
+		expect(buildVisitTodayReminderEntityIdForPerson(sharedId)).not.toBe(
+			buildVisitTodayReminderEntityId(sharedId)
 		);
 	});
 });

--- a/src/lib/server/email/scheduled-visit-reminder-utils.ts
+++ b/src/lib/server/email/scheduled-visit-reminder-utils.ts
@@ -25,6 +25,10 @@ export function buildScheduledVisitReminderEntityId(visitId: string): string {
 	return `scheduled_visit:${visitId}`;
 }
 
+export function buildScheduledVisitReminderEntityIdForPerson(personId: string): string {
+	return `scheduled_visit:person:${personId}`;
+}
+
 export function buildScheduledVisitReminderSubject(personName: string): string {
 	return `[Synapse] 📅 Upcoming visit with ${personName} in one week`;
 }
@@ -33,6 +37,10 @@ export const VISIT_TODAY_REMINDER_NOTIFICATION_TYPE = 'visit_today_reminder';
 
 export function buildVisitTodayReminderEntityId(visitId: string): string {
 	return `visit_today:${visitId}`;
+}
+
+export function buildVisitTodayReminderEntityIdForPerson(personId: string): string {
+	return `visit_today:person:${personId}`;
 }
 
 export function buildVisitTodayReminderSubject(personName: string): string {

--- a/src/lib/utils/visit-status.test.ts
+++ b/src/lib/utils/visit-status.test.ts
@@ -7,6 +7,7 @@ import {
 	convertVisitThresholdFromDays,
 	convertVisitThresholdToDays,
 	DEFAULT_VISIT_STATUS_THRESHOLDS,
+	getEffectiveFollowUpDate,
 	getStatusLabel,
 	getStatusPriority,
 	normalizeVisitStatusThresholds
@@ -133,6 +134,24 @@ describe('visit status boundary thresholds', () => {
 		expect(calculateVisitStatus(dateDaysAgo(50), today, customThresholds).status).toBe('green');
 		expect(calculateVisitStatus(dateDaysAgo(100), today, customThresholds).status).toBe('yellow');
 		expect(calculateVisitStatus(dateDaysAgo(130), today, customThresholds).status).toBe('red');
+	});
+});
+
+describe('getEffectiveFollowUpDate', () => {
+	it('uses the person-level scheduled date when there are no logged visits', () => {
+		expect(getEffectiveFollowUpDate(false, null, '2026-08-15')).toBe('2026-08-15');
+	});
+
+	it('returns null when there are no visits and no scheduled date', () => {
+		expect(getEffectiveFollowUpDate(false, null, null)).toBeNull();
+	});
+
+	it('prefers the latest visit follow-up date once a visit exists', () => {
+		expect(getEffectiveFollowUpDate(true, '2026-09-01', '2026-08-15')).toBe('2026-09-01');
+	});
+
+	it('ignores the person-level scheduled date once a visit exists, even if follow-up is unset', () => {
+		expect(getEffectiveFollowUpDate(true, null, '2026-08-15')).toBeNull();
 	});
 });
 

--- a/src/lib/utils/visit-status.ts
+++ b/src/lib/utils/visit-status.ts
@@ -166,6 +166,24 @@ export function calculatePersonVisitStatus(
 	};
 }
 
+/**
+ * The follow-up date that should drive a person's "scheduled" status.
+ * Once a person has at least one logged visit, that visit's own follow-up
+ * date is authoritative. Otherwise, fall back to the person-level scheduled
+ * visit date (set without ever logging a visit).
+ */
+export function getEffectiveFollowUpDate(
+	hasVisits: boolean,
+	latestVisitFollowUpDate: string | null | undefined,
+	personScheduledVisitDate: string | null | undefined
+): string | null {
+	if (hasVisits) {
+		return latestVisitFollowUpDate ?? null;
+	}
+
+	return personScheduledVisitDate ?? null;
+}
+
 export function getStatusPriority(status: VisitStatus): number {
 	return VISIT_STATUS_ORDER.indexOf(status) + 1;
 }

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -23,7 +23,11 @@ import {
 	getTodayString
 } from '$lib/utils/date';
 import { createMarkdownExcerpt } from '$lib/utils/markdown';
-import { calculatePersonVisitStatus, type VisitStatusThresholds } from '$lib/utils/visit-status';
+import {
+	calculatePersonVisitStatus,
+	getEffectiveFollowUpDate,
+	type VisitStatusThresholds
+} from '$lib/utils/visit-status';
 import { getWorkoutLabel } from '$lib/utils/workout';
 import { and, desc, eq, gte, lte, ne, sql } from 'drizzle-orm';
 
@@ -62,10 +66,16 @@ function getDayLabel(date: string, today: string, tomorrow: string): string {
 
 type UpcomingVisitRow = { personId: string; personName: string; date: string };
 type UpcomingFollowUpRow = { personId: string; personName: string; followUpDate: string | null };
+type UpcomingScheduledOnlyRow = {
+	personId: string;
+	personName: string;
+	scheduledVisitDate: string;
+};
 
 function buildUpcomingVisits(
 	byDateRaw: UpcomingVisitRow[],
 	byFollowUpRaw: UpcomingFollowUpRow[],
+	byScheduledOnlyRaw: UpcomingScheduledOnlyRow[],
 	today: string
 ): { dayLabel: string; names: string[]; isToday: boolean }[] {
 	const tomorrow = addDaysToDateString(today, 1);
@@ -85,6 +95,12 @@ function buildUpcomingVisits(
 		map.set(v.followUpDate, inner);
 	}
 
+	for (const v of byScheduledOnlyRaw) {
+		const inner = map.get(v.scheduledVisitDate) ?? new Map<string, string>();
+		inner.set(v.personId, v.personName);
+		map.set(v.scheduledVisitDate, inner);
+	}
+
 	return Array.from(map.entries())
 		.sort(([a], [b]) => a.localeCompare(b))
 		.map(([date, inner]) => ({
@@ -95,7 +111,7 @@ function buildUpcomingVisits(
 }
 
 function buildVisitHealth(
-	peopleRaw: { id: string; name: string; isExempt: boolean }[],
+	peopleRaw: { id: string; name: string; isExempt: boolean; scheduledVisitDate: string | null }[],
 	visitsMap: Map<string, { date: string; followUpDate: string | null }>,
 	today: string,
 	visitStatusThresholds: VisitStatusThresholds
@@ -115,10 +131,15 @@ function buildVisitHealth(
 	};
 	for (const person of peopleRaw) {
 		const latestVisit = visitsMap.get(person.id);
+		const effectiveFollowUpDate = getEffectiveFollowUpDate(
+			latestVisit !== undefined,
+			latestVisit?.followUpDate,
+			person.scheduledVisitDate
+		);
 		const { status } = calculatePersonVisitStatus(
 			latestVisit?.date ?? null,
 			person.isExempt,
-			latestVisit?.followUpDate ?? null,
+			effectiveFollowUpDate,
 			today,
 			visitStatusThresholds
 		);
@@ -156,7 +177,8 @@ async function runDashboardQueries(
 		recentTaskRaw,
 		recentVisitRaw,
 		upcomingVisitsByDateRaw,
-		upcomingFollowUpsByDateRaw
+		upcomingFollowUpsByDateRaw,
+		upcomingScheduledOnlyRaw
 	] = await Promise.all([
 		db
 			.select({ date: journalEntries.date, count: sql<number>`count(*)` })
@@ -252,7 +274,12 @@ async function runDashboardQueries(
 			.where(and(eq(workoutLogs.userId, userId), gte(workoutLogs.date, r.workout4WeeksStart)))
 			.groupBy(workoutLogs.type),
 		db
-			.select({ id: people.id, name: people.name, isExempt: people.isExempt })
+			.select({
+				id: people.id,
+				name: people.name,
+				isExempt: people.isExempt,
+				scheduledVisitDate: people.scheduledVisitDate
+			})
 			.from(people)
 			.where(and(eq(people.userId, userId), eq(people.isArchived, false))),
 		(() => {
@@ -312,7 +339,23 @@ async function runDashboardQueries(
 					lte(visits.followUpDate, r.upcomingEndDate)
 				)
 			)
-			.orderBy(visits.followUpDate)
+			.orderBy(visits.followUpDate),
+		db
+			.select({
+				personId: people.id,
+				personName: people.name,
+				scheduledVisitDate: people.scheduledVisitDate
+			})
+			.from(people)
+			.where(
+				and(
+					eq(people.userId, userId),
+					eq(people.isArchived, false),
+					gte(people.scheduledVisitDate, r.today),
+					lte(people.scheduledVisitDate, r.upcomingEndDate)
+				)
+			)
+			.orderBy(people.scheduledVisitDate)
 	]);
 
 	return {
@@ -333,7 +376,8 @@ async function runDashboardQueries(
 		recentTaskRaw,
 		recentVisitRaw,
 		upcomingVisitsByDateRaw,
-		upcomingFollowUpsByDateRaw
+		upcomingFollowUpsByDateRaw,
+		upcomingScheduledOnlyRaw
 	};
 }
 
@@ -592,6 +636,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 			upcomingVisits: buildUpcomingVisits(
 				data.upcomingVisitsByDateRaw,
 				data.upcomingFollowUpsByDateRaw,
+				data.upcomingScheduledOnlyRaw.filter(
+					(v): v is UpcomingScheduledOnlyRow => v.scheduledVisitDate !== null
+				),
 				today
 			),
 			recentActivity: buildActivityFeed(data),

--- a/src/routes/(app)/visits/+page.server.ts
+++ b/src/routes/(app)/visits/+page.server.ts
@@ -7,6 +7,7 @@ import { getTodayString } from '$lib/utils/date';
 import { safeParse } from '$lib/utils/json';
 import {
 	calculatePersonVisitStatus,
+	getEffectiveFollowUpDate,
 	getStatusPriority,
 	type PersonWithStatus
 } from '$lib/utils/visit-status';
@@ -50,14 +51,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 		const peopleWithStatus: PersonWithStatus[] = userPeople.map((person) => {
 			const latestVisit = latestVisitsByPersonId.get(person.id);
-			const latestFollowUpDate = latestVisit?.followUpDate ?? null;
+			const effectiveFollowUpDate = getEffectiveFollowUpDate(
+				latestVisit !== undefined,
+				latestVisit?.followUpDate,
+				person.scheduledVisitDate
+			);
 			const nextFollowUpDate =
-				latestFollowUpDate && latestFollowUpDate >= today ? latestFollowUpDate : null;
+				effectiveFollowUpDate && effectiveFollowUpDate >= today ? effectiveFollowUpDate : null;
 
 			const statusInfo = calculatePersonVisitStatus(
 				latestVisit?.date ?? null,
 				person.isExempt,
-				latestFollowUpDate,
+				effectiveFollowUpDate,
 				today,
 				visitStatusThresholds
 			);

--- a/src/routes/(app)/visits/[id]/+page.server.ts
+++ b/src/routes/(app)/visits/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import { logger } from '$lib';
-import { personSchema, visitSchema } from '$lib/schemas/visits';
+import { personSchema, scheduleVisitSchema, visitSchema } from '$lib/schemas/visits';
 import { getUser, requireAuth } from '$lib/server/actions/auth-guard';
 import {
 	getOwnedEntityOrNull,
@@ -16,7 +16,7 @@ import {
 import { getVisitStatusThresholdsForUser } from '$lib/server/visit-status-settings';
 import { getTodayString } from '$lib/utils/date';
 import { safeParse } from '$lib/utils/json';
-import { calculatePersonVisitStatus } from '$lib/utils/visit-status';
+import { calculatePersonVisitStatus, getEffectiveFollowUpDate } from '$lib/utils/visit-status';
 import { error, fail, isHttpError, isRedirect, redirect } from '@sveltejs/kit';
 import { and, desc, eq } from 'drizzle-orm';
 import { message, superValidate } from 'sveltekit-superforms';
@@ -56,10 +56,15 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
 		// Calculate status
 		const latestVisit = personVisits[0];
+		const effectiveFollowUpDate = getEffectiveFollowUpDate(
+			personVisits.length > 0,
+			latestVisit?.followUpDate,
+			person.scheduledVisitDate
+		);
 		const statusInfo = calculatePersonVisitStatus(
 			latestVisit?.date ?? null,
 			person.isExempt,
-			latestVisit?.followUpDate ?? null,
+			effectiveFollowUpDate,
 			getTodayString(),
 			visitStatusThresholds
 		);
@@ -69,6 +74,10 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 		visitForm.data.date = getTodayString(); // Set default to today
 
 		const editForm = await superValidate(person, zod4(personSchema));
+		const scheduleForm = await superValidate(
+			{ scheduledVisitDate: person.scheduledVisitDate ?? undefined },
+			zod4(scheduleVisitSchema)
+		);
 
 		return {
 			person: {
@@ -78,7 +87,8 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 			},
 			visits: parsedVisits,
 			visitForm,
-			editForm
+			editForm,
+			scheduleForm
 		};
 	} catch (err) {
 		if (isHttpError(err) || isRedirect(err)) throw err;
@@ -125,6 +135,14 @@ export const actions = {
 				followUpDate: form.data.followUpDate || null,
 				...withAuditFieldsForCreate()
 			});
+
+			// A real visit's follow-up date now takes over as the source of truth
+			if (person.scheduledVisitDate) {
+				await db
+					.update(people)
+					.set({ scheduledVisitDate: null, ...withAuditFieldsForUpdate() })
+					.where(and(eq(people.id, params.id), eq(people.userId, user.id)));
+			}
 
 			logger.info('Visit logged', {
 				visitId,
@@ -266,6 +284,84 @@ export const actions = {
 				},
 				{ status: 500 }
 			);
+		}
+	}),
+
+	scheduleVisit: requireAuth(async ({ request, params }, user) => {
+		const form = await superValidate(request, zod4(scheduleVisitSchema));
+
+		if (!form.valid) {
+			logger.warn('Invalid schedule visit form data', { errors: form.errors });
+			return fail(400, { form });
+		}
+
+		try {
+			const db = getDb();
+
+			// Verify person belongs to user
+			const person = await getOwnedEntityOrNull(() =>
+				db.query.people.findFirst({
+					where: and(eq(people.id, params.id), eq(people.userId, user.id))
+				})
+			);
+
+			if (!person) {
+				return fail(404, { error: 'Person not found' });
+			}
+
+			await db
+				.update(people)
+				.set({
+					scheduledVisitDate: form.data.scheduledVisitDate,
+					...withAuditFieldsForUpdate()
+				})
+				.where(and(eq(people.id, params.id), eq(people.userId, user.id)));
+
+			logger.info('Visit scheduled', { personId: params.id, userId: user.id });
+
+			return message(form, {
+				type: 'success',
+				text: 'Visit scheduled successfully!'
+			});
+		} catch (err) {
+			logger.error('Failed to schedule visit', err);
+			return message(
+				form,
+				{
+					type: 'error',
+					text: 'An error occurred while scheduling the visit. Please try again.'
+				},
+				{ status: 500 }
+			);
+		}
+	}),
+
+	cancelScheduledVisit: requireAuth(async ({ params }, user) => {
+		try {
+			const db = getDb();
+
+			// Verify person belongs to user
+			const person = await getOwnedEntityOrNull(() =>
+				db.query.people.findFirst({
+					where: and(eq(people.id, params.id), eq(people.userId, user.id))
+				})
+			);
+
+			if (!person) {
+				return fail(404, { error: 'Person not found' });
+			}
+
+			await db
+				.update(people)
+				.set({ scheduledVisitDate: null, ...withAuditFieldsForUpdate() })
+				.where(and(eq(people.id, params.id), eq(people.userId, user.id)));
+
+			logger.info('Scheduled visit cancelled', { personId: params.id, userId: user.id });
+
+			return { success: true };
+		} catch (err) {
+			logger.error('Failed to cancel scheduled visit', err);
+			return fail(500, { error: 'Failed to cancel scheduled visit' });
 		}
 	}),
 

--- a/src/routes/(app)/visits/[id]/+page.svelte
+++ b/src/routes/(app)/visits/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
@@ -7,10 +8,10 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { personSchema, visitSchema } from '$lib/schemas/visits';
+	import { personSchema, scheduleVisitSchema, visitSchema } from '$lib/schemas/visits';
 	import { formatDateLong, formatDateShort } from '$lib/utils/date';
 	import { getStatusLabel } from '$lib/utils/visit-status';
-	import { Archive, ArrowLeft, Calendar, Pencil, Trash2 } from '@lucide/svelte';
+	import { Archive, ArrowLeft, Calendar, CalendarClock, Pencil, Trash2 } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import { superForm } from 'sveltekit-superforms';
 	import { zod4 } from 'sveltekit-superforms/adapters';
@@ -21,6 +22,7 @@
 
 	let showLogVisitDialog = $state(false);
 	let showEditPersonDialog = $state(false);
+	let showScheduleVisitDialog = $state(false);
 	let showArchivePersonDialog = $state(false);
 	let showDeletePersonDialog = $state(false);
 	let editingVisitId = $state<string | null>(null);
@@ -60,6 +62,22 @@
 		})
 	);
 
+	let scheduleFormState = $derived(
+		superForm(data.scheduleForm, {
+			validators: zod4(scheduleVisitSchema),
+			onUpdated({ form }) {
+				if (form.message) {
+					if (form.message.type === 'success') {
+						toast.success(form.message.text);
+						showScheduleVisitDialog = false;
+					} else if (form.message.type === 'error') {
+						toast.error(form.message.text);
+					}
+				}
+			}
+		})
+	);
+
 	const {
 		form: visitForm,
 		errors: visitErrors,
@@ -73,6 +91,13 @@
 		enhance: editEnhance,
 		submitting: editSubmitting
 	} = $derived(editFormState);
+
+	const {
+		form: scheduleForm,
+		errors: scheduleErrors,
+		enhance: scheduleEnhance,
+		submitting: scheduleSubmitting
+	} = $derived(scheduleFormState);
 
 	const isEditingVisit = $derived(editingVisitId !== null);
 
@@ -99,6 +124,11 @@
 	function closeLogVisitDialog() {
 		showLogVisitDialog = false;
 		editingVisitId = null;
+	}
+
+	function openScheduleVisitDialog() {
+		$scheduleForm.scheduledVisitDate = data.person.scheduledVisitDate ?? '';
+		showScheduleVisitDialog = true;
 	}
 
 	const statusBadge: Record<string, string> = {
@@ -154,6 +184,11 @@
 							Last visit: {formatTimeSince(data.person.daysSinceLastVisit)}
 						</span>
 					{/if}
+					{#if data.visits.length === 0 && data.person.scheduledVisitDate}
+						<span class="text-muted-foreground text-sm">
+							Scheduled: {formatDateShort(data.person.scheduledVisitDate)}
+						</span>
+					{/if}
 				</div>
 			</div>
 			<div class="flex gap-2">
@@ -172,6 +207,27 @@
 					</Tooltip.Trigger>
 					<Tooltip.Content>Log Visit</Tooltip.Content>
 				</Tooltip.Root>
+
+				{#if data.visits.length === 0}
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									size="icon"
+									variant="outline"
+									aria-label="Schedule Visit"
+									onclick={openScheduleVisitDialog}
+								>
+									<CalendarClock class="h-4 w-4" />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>
+							{data.person.scheduledVisitDate ? 'Edit Scheduled Visit' : 'Schedule Visit'}
+						</Tooltip.Content>
+					</Tooltip.Root>
+				{/if}
 
 				<Tooltip.Root>
 					<Tooltip.Trigger>
@@ -235,7 +291,17 @@
 			<Card.Root>
 				<Card.Content class="py-12 text-center">
 					<p class="text-muted-foreground mb-4">No visits logged yet.</p>
-					<Button onclick={openLogVisitDialogForCreate}>Log First Visit</Button>
+					{#if data.person.scheduledVisitDate}
+						<p class="text-muted-foreground mb-4 text-sm">
+							Scheduled: {formatDateShort(data.person.scheduledVisitDate)}
+						</p>
+					{/if}
+					<div class="flex justify-center gap-2">
+						<Button onclick={openLogVisitDialogForCreate}>Log First Visit</Button>
+						<Button variant="outline" onclick={openScheduleVisitDialog}>
+							{data.person.scheduledVisitDate ? 'Edit Scheduled Visit' : 'Schedule Visit'}
+						</Button>
+					</div>
 				</Card.Content>
 			</Card.Root>
 		{:else}
@@ -470,6 +536,68 @@
 				</div>
 			</div>
 		</form>
+	</Dialog.Content>
+</Dialog.Root>
+
+<!-- Schedule Visit Dialog -->
+<Dialog.Root bind:open={showScheduleVisitDialog}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Schedule Visit</Dialog.Title>
+			<Dialog.Description>
+				Set a scheduled visit date for {data.person.name} without logging a visit
+			</Dialog.Description>
+		</Dialog.Header>
+
+		<div class="space-y-4">
+			<form method="POST" action="?/scheduleVisit" use:scheduleEnhance>
+				<div class="space-y-2">
+					<Label for="scheduledVisitDate">Scheduled Date*</Label>
+					<Input
+						id="scheduledVisitDate"
+						name="scheduledVisitDate"
+						type="date"
+						bind:value={$scheduleForm.scheduledVisitDate}
+						required
+						aria-invalid={$scheduleErrors.scheduledVisitDate ? 'true' : undefined}
+					/>
+					{#if $scheduleErrors.scheduledVisitDate}
+						<p class="text-destructive mt-1 text-sm">{$scheduleErrors.scheduledVisitDate}</p>
+					{/if}
+				</div>
+
+				<div class="mt-4 flex justify-end gap-2">
+					<Button type="button" variant="outline" onclick={() => (showScheduleVisitDialog = false)}>
+						Cancel
+					</Button>
+					<Button type="submit" disabled={$scheduleSubmitting}>
+						{$scheduleSubmitting ? 'Saving...' : 'Save'}
+					</Button>
+				</div>
+			</form>
+
+			{#if data.person.scheduledVisitDate}
+				<form
+					method="POST"
+					action="?/cancelScheduledVisit"
+					use:enhance={() => {
+						showScheduleVisitDialog = false;
+
+						return async ({ result, update }) => {
+							if (result.type === 'success') {
+								toast.success('Scheduled visit cleared');
+							} else {
+								toast.error('Failed to clear scheduled visit');
+							}
+
+							await update();
+						};
+					}}
+				>
+					<Button type="submit" variant="ghost" class="w-full">Clear Schedule</Button>
+				</form>
+			{/if}
+		</div>
 	</Dialog.Content>
 </Dialog.Root>
 


### PR DESCRIPTION
## Summary
- Fixes #283: previously a scheduled/follow-up visit date could only be set on a `visits` row, so a person with zero logged visits had no way to be scheduled.
- Adds a nullable `scheduledVisitDate` column on `people`, plus a "Schedule Visit" dialog on the person detail page shown only for people with no visit history.
- Once a real visit is logged, the visit's own follow-up date takes over as the source of truth and the person-level scheduled date is cleared automatically.
- Wires the effective follow-up date (visit-based if any visits exist, otherwise the person-level scheduled date) into the visits list status, the dashboard's upcoming-visits panel / visit-health counts, and the scheduled-visit / visit-today reminder emails (new person-based entity IDs so they don't collide with visit-based reminder IDs).

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — no new issues (pre-existing dead-code/dependency warnings unrelated to this change)
- [x] `npm test` — 345 tests passing, including new unit tests for `getEffectiveFollowUpDate`, `scheduleVisitSchema`, and the new reminder entity-id builders
- [x] Manually verified end-to-end against a running dev server (throwaway test account + person, cleaned up afterward): scheduling a visit with 0 logged visits shows the purple "Scheduled" badge and appears in the visits list "Scheduled" tab and dashboard upcoming-visits panel; cancelling clears it; logging a real visit clears the person-level schedule and hides the "Schedule Visit" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)