### PR TITLE
Add Admin dashboard for viewing users and archived persons

### DIFF
--- a/src/lib/components/admin/AdminArchivedPersonsTable.svelte
+++ b/src/lib/components/admin/AdminArchivedPersonsTable.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import * as Table from '$lib/components/ui/table';
+	import type { people } from '$lib/server/db/schema';
+	import { formatDateMedium } from '$lib/utils/date';
+
+	type ArchivedPerson = typeof people.$inferSelect & {
+		ownerEmail: string;
+		lastVisitDate: string | null;
+	};
+
+	let { people: archivedPeople }: { people: ArchivedPerson[] } = $props();
+
+	let unarchiveDialogOpen = $state(false);
+	let personToUnarchive = $state<ArchivedPerson | null>(null);
+
+	function openUnarchiveDialog(person: ArchivedPerson) {
+		personToUnarchive = person;
+		unarchiveDialogOpen = true;
+	}
+</script>
+
+<div class="overflow-x-auto rounded-xl border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Owner</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Exempt</Table.Head>
+				<Table.Head>Last Visit Date</Table.Head>
+				<Table.Head>Archived Date</Table.Head>
+				<Table.Head class="text-right">Actions</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if archivedPeople.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={6} class="text-muted-foreground text-center"
+						>No archived persons found.</Table.Cell
+					>
+				</Table.Row>
+			{:else}
+				{#each archivedPeople as person (person.id)}
+					<Table.Row>
+						<Table.Cell>{person.ownerEmail}</Table.Cell>
+						<Table.Cell>{person.name}</Table.Cell>
+						<Table.Cell>
+							<Badge variant={person.isExempt ? 'default' : 'outline'}>
+								{person.isExempt ? 'Yes' : 'No'}
+							</Badge>
+						</Table.Cell>
+						<Table.Cell>
+							{person.lastVisitDate ? formatDateMedium(person.lastVisitDate) : '—'}
+						</Table.Cell>
+						<Table.Cell>
+							{person.archivedAt ? formatDateMedium(person.archivedAt.slice(0, 10)) : '—'}
+						</Table.Cell>
+						<Table.Cell class="text-right">
+							<Button variant="outline" size="sm" onclick={() => openUnarchiveDialog(person)}>
+								Unarchive
+							</Button>
+						</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>
+
+<ConfirmDialog
+	bind:open={unarchiveDialogOpen}
+	title="Unarchive Person"
+	message={`Unarchive ${personToUnarchive?.name}? They will reappear in ${personToUnarchive?.ownerEmail}'s visits list.`}
+	confirmButtonText="Unarchive"
+	actionUrl="?/unarchivePerson"
+	hiddenFields={{ personId: personToUnarchive?.id ?? '' }}
+/>

--- a/src/lib/components/admin/AdminUsersTable.svelte
+++ b/src/lib/components/admin/AdminUsersTable.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Table from '$lib/components/ui/table';
+	import type { User } from '$lib/types';
+
+	let { users }: { users: User[] } = $props();
+</script>
+
+<div class="overflow-x-auto rounded-xl border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Email</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Role</Table.Head>
+				<Table.Head>Status</Table.Head>
+				<Table.Head>Created Date</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if users.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={5} class="text-muted-foreground text-center"
+						>No users found.</Table.Cell
+					>
+				</Table.Row>
+			{:else}
+				{#each users as user (user.id)}
+					<Table.Row>
+						<Table.Cell>{user.email}</Table.Cell>
+						<Table.Cell>{user.name}</Table.Cell>
+						<Table.Cell>
+							<Badge variant={user.role === 'admin' ? 'default' : 'outline'}>{user.role}</Badge>
+						</Table.Cell>
+						<Table.Cell>
+							<Badge variant={user.banned ? 'destructive' : 'secondary'}>
+								{user.banned ? 'Banned' : 'Active'}
+							</Badge>
+						</Table.Cell>
+						<Table.Cell>{new Date(user.createdAt).toLocaleDateString()}</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/src/lib/server/actions/auth-guard.test.ts
+++ b/src/lib/server/actions/auth-guard.test.ts
@@ -2,7 +2,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { isRedirect } from '@sveltejs/kit';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getUser, requireAuth } from './auth-guard';
+import { getUser, requireAdmin, requireAuth } from './auth-guard';
 
 type MockLocals = App.Locals;
 
@@ -19,7 +19,8 @@ function makeEvent(overrides: Partial<MockLocals> = {}): RequestEvent {
 	return { locals: makeLocals(overrides) } as unknown as RequestEvent;
 }
 
-const mockUser = { id: 'user_123', name: 'Alice', email: 'alice@example.com' };
+const mockUser = { id: 'user_123', name: 'Alice', email: 'alice@example.com', role: 'user' };
+const mockAdminUser = { id: 'admin_123', name: 'Admin', email: 'admin@example.com', role: 'admin' };
 
 describe('requireAuth', () => {
 	it('returns fail(401) when the user is not authenticated', async () => {
@@ -55,6 +56,34 @@ describe('requireAuth', () => {
 		await wrapped(makeEvent({ user: mockUser as App.Locals['user'] }));
 
 		expect(capturedUser).toBe(mockUser);
+	});
+});
+
+describe('requireAdmin', () => {
+	it('returns fail(401) when the user is not authenticated', async () => {
+		const wrapped = requireAdmin(async () => ({ ok: true }));
+		const result = await wrapped(makeEvent());
+
+		expect(result).toMatchObject({ status: 401 });
+	});
+
+	it('returns fail(403) when the user is authenticated but not an admin', async () => {
+		const wrapped = requireAdmin(async () => ({ ok: true }));
+		const result = await wrapped(makeEvent({ user: mockUser as App.Locals['user'] }));
+
+		expect(result).toMatchObject({ status: 403 });
+	});
+
+	it('calls the handler and returns its result when the user is an admin', async () => {
+		const handler = vi
+			.fn<() => Promise<{ success: boolean }>>()
+			.mockResolvedValue({ success: true });
+		const wrapped = requireAdmin(handler);
+
+		const result = await wrapped(makeEvent({ user: mockAdminUser as App.Locals['user'] }));
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(result).toEqual({ success: true });
 	});
 });
 

--- a/src/lib/server/actions/auth-guard.ts
+++ b/src/lib/server/actions/auth-guard.ts
@@ -50,3 +50,34 @@ export function getUser(locals: App.Locals): User {
 	}
 	return locals.user;
 }
+
+/**
+ * Authorization wrapper for SvelteKit actions.
+ * Ensures the user is authenticated and has the 'admin' role before executing the action handler.
+ *
+ * @param handler - The action handler function that requires admin access
+ * @returns A wrapped action handler that performs auth + role check
+ *
+ * @example
+ * export const actions = {
+ *   unarchivePerson: requireAdmin(async (event, user) => {
+ *     // user is guaranteed to be an authenticated admin here
+ *   })
+ * };
+ */
+export function requireAdmin<
+	T,
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>
+>(
+	handler: (event: RequestEvent<Params>, user: User) => Promise<T>
+): (event: RequestEvent<Params>) => Promise<T | ReturnType<typeof fail>> {
+	return async (event: RequestEvent<Params>) => {
+		if (!event.locals.user) {
+			return fail(401, { error: 'Unauthorized' });
+		}
+		if (event.locals.user.role !== 'admin') {
+			return fail(403, { error: 'Forbidden' });
+		}
+		return handler(event, event.locals.user);
+	};
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -143,6 +143,12 @@ export const auth = betterAuth({
 			generateId: () => crypto.randomUUID()
 		}
 	},
+	user: {
+		additionalFields: {
+			role: { type: 'string', required: false, defaultValue: 'user', input: false },
+			banned: { type: 'boolean', required: false, defaultValue: false, input: false }
+		}
+	},
 	session: {
 		expiresIn: 60 * 60 * 24 * 7, // 7 days
 		updateAge: 60 * 60 * 24, // Update every 24 hours

--- a/src/lib/server/db/migrations/0022_rich_komodo.sql
+++ b/src/lib/server/db/migrations/0022_rich_komodo.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `people` ADD `archived_at` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `role` text DEFAULT 'user' NOT NULL;--> statement-breakpoint
+ALTER TABLE `user` ADD `banned` integer DEFAULT false NOT NULL;

--- a/src/lib/server/db/migrations/meta/0022_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0022_snapshot.json
@@ -1,0 +1,1995 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "8672d5cf-ccee-4b42-a440-2662a7c87355",
+	"prevId": "891eea95-ecb5-4c8d-9b02-7c66ec214993",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshTokenUpdatedAt": {
+					"name": "refreshTokenUpdatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_entries": {
+			"name": "daily_agenda_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"completed": {
+					"name": "completed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_entries_user_date_idx": {
+					"name": "daily_agenda_entries_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_group_date_idx": {
+					"name": "daily_agenda_entries_group_date_idx",
+					"columns": ["template_group_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_default_unique_idx": {
+					"name": "daily_agenda_entries_default_unique_idx",
+					"columns": ["user_id", "template_group_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_entries_user_id_user_id_fk": {
+					"name": "daily_agenda_entries_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"daily_agenda_entries_template_id_daily_agenda_templates_id_fk": {
+					"name": "daily_agenda_entries_template_id_daily_agenda_templates_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "daily_agenda_templates",
+					"columnsFrom": ["template_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_templates": {
+			"name": "daily_agenda_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[0,1,2,3,4,5,6]'"
+				},
+				"starts_on": {
+					"name": "starts_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ends_on": {
+					"name": "ends_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_templates_user_range_idx": {
+					"name": "daily_agenda_templates_user_range_idx",
+					"columns": ["user_id", "starts_on", "ends_on"],
+					"isUnique": false
+				},
+				"daily_agenda_templates_group_idx": {
+					"name": "daily_agenda_templates_group_idx",
+					"columns": ["template_group_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_templates_user_id_user_id_fk": {
+					"name": "daily_agenda_templates_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_templates",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_calorie_targets": {
+			"name": "daily_calorie_targets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_calories": {
+					"name": "target_calories",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_calorie_targets_user_id_unique": {
+					"name": "daily_calorie_targets_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_calorie_targets_user_id_user_id_fk": {
+					"name": "daily_calorie_targets_user_id_user_id_fk",
+					"tableFrom": "daily_calorie_targets",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_notifications": {
+			"name": "email_notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notification_type": {
+					"name": "notification_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_subject": {
+					"name": "email_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_notifications_userId_user_id_fk": {
+					"name": "email_notifications_userId_user_id_fk",
+					"tableFrom": "email_notifications",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"goal_weights": {
+			"name": "goal_weights",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_weight_lbs": {
+					"name": "target_weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"goal_weights_user_id_unique": {
+					"name": "goal_weights_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"goal_weights_user_id_user_id_fk": {
+					"name": "goal_weights_user_id_user_id_fk",
+					"tableFrom": "goal_weights",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"journal_entries": {
+			"name": "journal_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weather": {
+					"name": "weather",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"journal_entries_user_id_user_id_fk": {
+					"name": "journal_entries_user_id_user_id_fk",
+					"tableFrom": "journal_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meal_logs": {
+			"name": "meal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time_of_day": {
+					"name": "time_of_day",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"calories_estimate": {
+					"name": "calories_estimate",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meal_logs_user_id_user_id_fk": {
+					"name": "meal_logs_user_id_user_id_fk",
+					"tableFrom": "meal_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_routines": {
+			"name": "meditation_routines",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"link_url": {
+					"name": "link_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood_tags": {
+					"name": "mood_tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_predefined": {
+					"name": "is_predefined",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_routines_user_id_user_id_fk": {
+					"name": "meditation_routines_user_id_user_id_fk",
+					"tableFrom": "meditation_routines",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_schedules": {
+			"name": "meditation_schedules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_schedules_user_id_user_id_fk": {
+					"name": "meditation_schedules_user_id_user_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_schedules_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_schedules_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_sessions": {
+			"name": "meditation_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pre_mood_rating": {
+					"name": "pre_mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mood_rating": {
+					"name": "mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_sessions_user_id_user_id_fk": {
+					"name": "meditation_sessions_user_id_user_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_sessions_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_sessions_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mood_logs": {
+			"name": "mood_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood": {
+					"name": "mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"custom_mood": {
+					"name": "custom_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mood_logs_user_date_idx": {
+					"name": "mood_logs_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"mood_logs_user_date_unique_idx": {
+					"name": "mood_logs_user_date_unique_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"mood_logs_user_id_user_id_fk": {
+					"name": "mood_logs_user_id_user_id_fk",
+					"tableFrom": "mood_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"people": {
+			"name": "people",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_exempt": {
+					"name": "is_exempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scheduled_visit_date": {
+					"name": "scheduled_visit_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"people_user_id_user_id_fk": {
+					"name": "people_user_id_user_id_fk",
+					"tableFrom": "people",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tasks": {
+			"name": "tasks",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"task_number": {
+					"name": "task_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_date": {
+					"name": "due_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'new'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tasks_task_number_unique": {
+					"name": "tasks_task_number_unique",
+					"columns": ["task_number"],
+					"isUnique": true
+				},
+				"tasks_user_state_sort_idx": {
+					"name": "tasks_user_state_sort_idx",
+					"columns": ["user_id", "state", "sort_order"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tasks_user_id_user_id_fk": {
+					"name": "tasks_user_id_user_id_fk",
+					"tableFrom": "tasks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visit_status_settings": {
+			"name": "visit_status_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recent_to_overdue_days": {
+					"name": "recent_to_overdue_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"overdue_to_critical_days": {
+					"name": "overdue_to_critical_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"visit_status_settings_user_id_unique": {
+					"name": "visit_status_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"visit_status_settings_user_id_user_id_fk": {
+					"name": "visit_status_settings_user_id_user_id_fk",
+					"tableFrom": "visit_status_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visits": {
+			"name": "visits",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"person_id": {
+					"name": "person_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"companions": {
+					"name": "companions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"follow_up_date": {
+					"name": "follow_up_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"visits_person_id_people_id_fk": {
+					"name": "visits_person_id_people_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "people",
+					"columnsFrom": ["person_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"visits_user_id_user_id_fk": {
+					"name": "visits_user_id_user_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"weight_entries": {
+			"name": "weight_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"weight_entries_user_id_user_id_fk": {
+					"name": "weight_entries_user_id_user_id_fk",
+					"tableFrom": "weight_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_exercises": {
+			"name": "workout_exercises",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_log_id": {
+					"name": "workout_log_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exercise_name": {
+					"name": "exercise_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sets": {
+					"name": "sets",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reps": {
+					"name": "reps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_exercises_workout_log_id_workout_logs_id_fk": {
+					"name": "workout_exercises_workout_log_id_workout_logs_id_fk",
+					"tableFrom": "workout_exercises",
+					"tableTo": "workout_logs",
+					"columnsFrom": ["workout_log_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_logs": {
+			"name": "workout_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"steps": {
+					"name": "steps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_logs_user_id_user_id_fk": {
+					"name": "workout_logs_user_id_user_id_fk",
+					"tableFrom": "workout_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_reminders": {
+			"name": "workout_reminders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_type": {
+					"name": "workout_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_reminders_user_id_user_id_fk": {
+					"name": "workout_reminders_user_id_user_id_fk",
+					"tableFrom": "workout_reminders",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
 			"when": 1785649392677,
 			"tag": "0021_lonely_thing",
 			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "6",
+			"when": 1785714523498,
+			"tag": "0022_rich_komodo",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -14,6 +14,8 @@ export const user = sqliteTable('user', {
 	email: text('email').notNull().unique(),
 	emailVerified: integer('emailVerified', { mode: 'boolean' }).notNull().default(false),
 	image: text('image'),
+	role: text('role').notNull().default('user'),
+	banned: integer('banned', { mode: 'boolean' }).notNull().default(false),
 	createdAt: integer('createdAt', { mode: 'timestamp' })
 		.notNull()
 		.$defaultFn(() => new Date()),
@@ -618,6 +620,7 @@ export const people = sqliteTable('people', {
 	name: text('name').notNull(),
 	isExempt: integer('is_exempt', { mode: 'boolean' }).notNull().default(false),
 	isArchived: integer('is_archived', { mode: 'boolean' }).notNull().default(false),
+	archivedAt: text('archived_at'),
 	scheduledVisitDate: text('scheduled_visit_date'),
 	createdAt: text('created_at')
 		.notNull()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type SidebarNav = {
 		icon?: Component;
 		color?: string;
 		items?: { title: string; url: string }[];
+		adminOnly?: boolean;
 	}[];
 };
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -11,6 +11,10 @@
 	import '../../app.css';
 
 	let { data, children } = $props();
+
+	const filteredNavItems = $derived({
+		navMain: navItems.navMain.filter((item) => !item.adminOnly || data.user?.role === 'admin')
+	});
 </script>
 
 <ModeWatcher />
@@ -18,7 +22,7 @@
 <Tooltip.Provider>
 	<Sidebar.Provider style="--header-height: calc(var(--spacing) * 12);">
 		{#if data.user}
-			<AppSidebar {navItems} user={data.user} />
+			<AppSidebar navItems={filteredNavItems} user={data.user} />
 			<Sidebar.Inset>
 				<SiteHeader />
 				<main class="flex min-w-0 flex-1 flex-col space-y-4 p-4 md:py-2">{@render children()}</main>

--- a/src/routes/(app)/admin/+layout.server.ts
+++ b/src/routes/(app)/admin/+layout.server.ts
@@ -1,0 +1,16 @@
+import { getUser } from '$lib/server/actions/auth-guard';
+import { error } from '@sveltejs/kit';
+
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	const user = getUser(locals);
+
+	if (user.role !== 'admin') {
+		error(403, 'Forbidden');
+	}
+
+	return {
+		user
+	};
+};

--- a/src/routes/(app)/admin/+page.server.ts
+++ b/src/routes/(app)/admin/+page.server.ts
@@ -1,0 +1,85 @@
+import { logger } from '$lib';
+import { requireAdmin } from '$lib/server/actions/auth-guard';
+import { getDb } from '$lib/server/db';
+import { people, user, visits } from '$lib/server/db/schema';
+import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
+import { fail } from '@sveltejs/kit';
+import { asc, desc, eq, inArray } from 'drizzle-orm';
+
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const db = getDb();
+
+		const [users, archivedPeople] = await Promise.all([
+			db.query.user.findMany({ orderBy: [desc(user.createdAt)] }),
+			db.query.people.findMany({
+				where: eq(people.isArchived, true),
+				orderBy: [desc(people.updatedAt)]
+			})
+		]);
+
+		const ownerIds = [...new Set(archivedPeople.map((person) => person.userId))];
+		const owners =
+			ownerIds.length > 0
+				? await db.query.user.findMany({ where: inArray(user.id, ownerIds) })
+				: [];
+		const ownerEmailById = new Map(owners.map((owner) => [owner.id, owner.email]));
+
+		const latestVisitsByPersonId = new Map<string, typeof visits.$inferSelect>();
+
+		if (archivedPeople.length > 0) {
+			const orderedVisits = await db.query.visits.findMany({
+				where: inArray(
+					visits.personId,
+					archivedPeople.map((person) => person.id)
+				),
+				orderBy: [asc(visits.personId), desc(visits.date), desc(visits.createdAt)]
+			});
+
+			for (const visit of orderedVisits) {
+				if (!latestVisitsByPersonId.has(visit.personId)) {
+					latestVisitsByPersonId.set(visit.personId, visit);
+				}
+			}
+		}
+
+		return {
+			users,
+			archivedPeople: archivedPeople.map((person) => ({
+				...person,
+				ownerEmail: ownerEmailById.get(person.userId) ?? 'Unknown',
+				lastVisitDate: latestVisitsByPersonId.get(person.id)?.date ?? null
+			}))
+		};
+	} catch (err) {
+		logger.error('Failed to load admin dashboard data', err);
+		return { users: [], archivedPeople: [] };
+	}
+};
+
+export const actions = {
+	unarchivePerson: requireAdmin(async ({ request }) => {
+		const formData = await request.formData();
+		const personId = formData.get('personId') as string;
+
+		if (!personId) {
+			return fail(400, { error: 'Person ID is required' });
+		}
+
+		try {
+			const db = getDb();
+
+			await db
+				.update(people)
+				.set({ isArchived: false, archivedAt: null, ...withAuditFieldsForUpdate() })
+				.where(eq(people.id, personId));
+
+			logger.info('Person unarchived', { personId });
+		} catch (err) {
+			logger.error('Failed to unarchive person', err);
+			return fail(500, { error: 'Failed to unarchive person' });
+		}
+	})
+} satisfies Actions;

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import AdminArchivedPersonsTable from '$lib/components/admin/AdminArchivedPersonsTable.svelte';
+	import AdminUsersTable from '$lib/components/admin/AdminUsersTable.svelte';
+	import PageShell from '$lib/components/app/PageShell.svelte';
+	import * as Tabs from '$lib/components/ui/tabs';
+
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const activeTab = $derived.by(() =>
+		page.url.searchParams.get('tab') === 'archived-persons' ? 'archived-persons' : 'users'
+	);
+
+	async function switchTab(tab: string) {
+		const url = new URL(page.url);
+		if (tab === 'users') {
+			url.searchParams.delete('tab');
+		} else {
+			url.searchParams.set('tab', tab);
+		}
+		await goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
+	}
+</script>
+
+<PageShell class="min-w-0 overflow-x-hidden">
+	<div class="mb-4 sm:mb-5">
+		<h1 class="font-display text-2xl font-bold sm:text-3xl">Admin</h1>
+		<p class="text-muted-foreground text-sm sm:text-base">Manage users and archived contacts</p>
+	</div>
+
+	<Tabs.Root value={activeTab} class="w-full gap-3">
+		<Tabs.List
+			class="bg-muted/75 text-muted-foreground grid h-11 w-full grid-cols-2 rounded-xl p-1"
+		>
+			<Tabs.Trigger
+				value="users"
+				class="font-display border-b-2 border-transparent data-[state=active]:border-red-500"
+				onclick={() => {
+					if (activeTab !== 'users') void switchTab('users');
+				}}
+			>
+				Users
+			</Tabs.Trigger>
+			<Tabs.Trigger
+				value="archived-persons"
+				class="font-display border-b-2 border-transparent data-[state=active]:border-red-500"
+				onclick={() => {
+					if (activeTab !== 'archived-persons') void switchTab('archived-persons');
+				}}
+			>
+				Archived Persons
+			</Tabs.Trigger>
+		</Tabs.List>
+
+		<Tabs.Content value="users" class="mt-0 w-full space-y-4">
+			<AdminUsersTable users={data.users} />
+		</Tabs.Content>
+
+		<Tabs.Content value="archived-persons" class="mt-0 w-full space-y-4">
+			<AdminArchivedPersonsTable people={data.archivedPeople} />
+		</Tabs.Content>
+	</Tabs.Root>
+</PageShell>

--- a/src/routes/(app)/sidebar.ts
+++ b/src/routes/(app)/sidebar.ts
@@ -1,5 +1,5 @@
 import type { SidebarNav } from '$lib/types';
-import { Book, Dumbbell, Heart, House, SquareCheck, Users } from '@lucide/svelte/icons';
+import { Book, Dumbbell, Heart, House, Shield, SquareCheck, Users } from '@lucide/svelte/icons';
 
 export const navItems: SidebarNav = {
 	navMain: [
@@ -44,6 +44,14 @@ export const navItems: SidebarNav = {
 			url: '/visits',
 			icon: Users,
 			color: 'text-pink-600 dark:text-pink-400'
+		},
+		{
+			title: 'Admin',
+			description: 'Manage users and archived contacts',
+			url: '/admin',
+			icon: Shield,
+			color: 'text-red-600 dark:text-red-400',
+			adminOnly: true
 		}
 	]
 };

--- a/src/routes/(app)/visits/[id]/+page.server.ts
+++ b/src/routes/(app)/visits/[id]/+page.server.ts
@@ -384,6 +384,7 @@ export const actions = {
 				.update(people)
 				.set({
 					isArchived: true,
+					archivedAt: new Date().toISOString(),
 					...withAuditFieldsForUpdate()
 				})
 				.where(and(eq(people.id, params.id), eq(people.userId, user.id)));


### PR DESCRIPTION
## Summary

Closes #284. Adds a new "Admin" section to the sidebar (below Visits, visible only to admins) with two read-only tabs:

- **Users** — Email, Name, Role, Status, Created Date
- **Archived Persons** — Owner, Name, Exempt, Last Visit Date, Archived Date, with an **Unarchive** button (archiving previously had no reverse path anywhere in the app)

Row-level user-management actions (Set Role, Set Password, Ban/Unban, Sessions, Delete) from the original issue text were explicitly scoped out for this pass at the reporter's request — this PR is display + unarchive only.

## Implementation notes

- Adds `role`/`banned` to `user` and `archivedAt` to `people` via a new migration (`0022_rich_komodo.sql`).
- `role`/`banned` are exposed through better-auth's `user.additionalFields` config so they actually flow into the session and `locals.user` (custom Drizzle columns aren't included in the session by default without this).
- New `requireAdmin` action guard + `src/routes/(app)/admin/+layout.server.ts` route guard (403 for non-admins).
- Sidebar nav is filtered client-side by `role` so the Admin item only renders for admins.
- Archived Persons view is global across all accounts (not just the admin's own), since this is an admin oversight feature.
- Bootstrapped the local dev DB's `gsheppard.yang@gmail.com` account to `role = 'admin'` via a one-off SQL update — same needs doing in any other environment before this is usable.

## Test plan

- [x] `npm run check`, `npm run lint`, `npm run test` all pass (348 tests, including new `requireAdmin` coverage in `auth-guard.test.ts`)
- [x] Manually verified end-to-end with Playwright against the dev server: admin sign-in shows the Admin nav item, `/admin` renders both tabs with correct columns/data, unarchive removes a row from the table and persists (`is_archived = 0`, `archived_at` cleared) in the DB
- [x] Verified a non-admin account does **not** see the Admin nav item and gets a 403 navigating to `/admin` directly
- [ ] Bootstrap `role = 'admin'` for the appropriate account(s) in staging/production before merging is user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)