### PR TITLE
feat: dashboard refinements from #282

### DIFF
--- a/src/lib/components/dashboard/AgendaCompletionChart.svelte
+++ b/src/lib/components/dashboard/AgendaCompletionChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Chart from '$lib/components/ui/chart/index.js';
 	import { scalePoint } from 'd3-scale';
-	import { AreaChart } from 'layerchart';
+	import { Area, AreaChart, Labels } from 'layerchart';
 
 	interface TrendPoint {
 		weekLabel: string;
@@ -46,13 +46,14 @@
 			Complete more daily agenda items to see your trend.
 		</div>
 	{:else}
-		<Chart.Container config={chartConfig} class="h-32 w-full">
+		<Chart.Container config={chartConfig} class="h-40 w-full">
 			<AreaChart
 				data={trend}
 				x="weekLabel"
 				y="completionPct"
 				xScale={scalePoint()}
 				axis="x"
+				padding={{ top: 20 }}
 				series={[
 					{
 						key: 'completionPct',
@@ -67,6 +68,16 @@
 					xAxis: { format: (v: string) => v }
 				}}
 			>
+				{#snippet marks({ context }: { context: any })}
+					{#each context.series.visibleSeries as s (s.key)}
+						<Area seriesKey={s.key} fillOpacity={0.2} line={{ strokeWidth: 2 }} />
+					{/each}
+					<Labels
+						seriesKey="completionPct"
+						format={(v: number) => `${v}%`}
+						class="fill-[oklch(var(--color-orange))] text-[10px] font-medium"
+					/>
+				{/snippet}
 				{#snippet tooltip()}
 					<Chart.Tooltip labelFormatter={(v: string) => v} indicator="line" />
 				{/snippet}

--- a/src/lib/components/dashboard/VisitHealthPanel.svelte
+++ b/src/lib/components/dashboard/VisitHealthPanel.svelte
@@ -129,7 +129,7 @@
 				<p class="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
 					Scheduled
 				</p>
-				<div class="space-y-1.5">
+				<div class="max-h-56 space-y-1.5 overflow-y-auto">
 					{#each upcomingVisits as day (day.dayLabel)}
 						<div class="flex items-start gap-2 text-xs">
 							<span

--- a/src/lib/components/dashboard/WorkoutTypeChart.svelte
+++ b/src/lib/components/dashboard/WorkoutTypeChart.svelte
@@ -22,17 +22,42 @@
 	);
 
 	const totalSessions = $derived(breakdown.reduce((sum, d) => sum + d.count, 0));
+
+	// Thresholds are per the dashboard goal of ~3 workouts/week over the trailing 4 weeks.
+	const workoutPace = $derived.by(() => {
+		if (totalSessions >= 12) {
+			return {
+				textClass: 'text-[oklch(var(--color-green))]',
+				barColor: 'oklch(var(--color-green))',
+				message: "Great pace — you're hitting 3+ workouts a week."
+			};
+		}
+		if (totalSessions >= 8) {
+			return {
+				textClass: 'text-amber-500',
+				barColor: '#f59e0b',
+				message: 'Below pace — aim for 3 workouts a week to catch up.'
+			};
+		}
+		return {
+			textClass: 'text-destructive',
+			barColor: 'var(--destructive)',
+			message: "You're falling behind — try to get moving more this week."
+		};
+	});
 </script>
 
 <div class="flex h-full flex-col gap-3">
 	<div class="flex items-end gap-3">
-		<span
-			class="font-display text-5xl leading-none font-bold text-[oklch(var(--color-green))] tabular-nums"
-		>
+		<span class="font-display text-5xl leading-none font-bold tabular-nums {workoutPace.textClass}">
 			{totalSessions}
 		</span>
 		<span class="text-muted-foreground mb-1 text-sm">sessions in 4 weeks</span>
 	</div>
+
+	{#if chartData.length > 0}
+		<p class="text-sm font-medium {workoutPace.textClass}">{workoutPace.message}</p>
+	{/if}
 
 	{#if chartData.length === 0}
 		<div
@@ -45,7 +70,7 @@
 			<BarChart
 				data={chartData}
 				x="type"
-				series={[{ key: 'count', label: 'Sessions', color: 'oklch(var(--color-green))' }]}
+				series={[{ key: 'count', label: 'Sessions', color: workoutPace.barColor }]}
 				props={{
 					xAxis: { format: (v: string) => v }
 				}}

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -20,6 +20,7 @@ import {
 	formatTimestampMedium,
 	formatTimestampShort,
 	formatTodayLabel,
+	getISODayOfWeek,
 	getTodayString
 } from '$lib/utils/date';
 import { createMarkdownExcerpt } from '$lib/utils/markdown';
@@ -171,6 +172,9 @@ async function runDashboardQueries(
 		tasksCompletionRaw,
 		openHighPriorityResult,
 		openTotalResult,
+		dueSoonTasksRaw,
+		openHighPriorityTitlesRaw,
+		openTotalTitlesRaw,
 		workoutTypeBreakdownRaw,
 		allPeopleRaw,
 		allVisitsRaw,
@@ -250,7 +254,7 @@ async function runDashboardQueries(
 				)
 			),
 		db
-			.select({ completedAt: tasks.completedAt })
+			.select({ title: tasks.title, completedAt: tasks.completedAt })
 			.from(tasks)
 			.where(
 				and(
@@ -268,6 +272,31 @@ async function runDashboardQueries(
 			.select({ count: sql<number>`count(*)` })
 			.from(tasks)
 			.where(and(eq(tasks.userId, userId), ne(tasks.state, 'done'))),
+		db
+			.select({ id: tasks.id, title: tasks.title, dueDate: tasks.dueDate })
+			.from(tasks)
+			.where(
+				and(
+					eq(tasks.userId, userId),
+					ne(tasks.state, 'done'),
+					gte(tasks.dueDate, r.today),
+					lte(tasks.dueDate, r.dueSoonEndDate)
+				)
+			)
+			.orderBy(tasks.dueDate)
+			.limit(6),
+		db
+			.select({ title: tasks.title })
+			.from(tasks)
+			.where(and(eq(tasks.userId, userId), ne(tasks.state, 'done'), lte(tasks.priority, 2)))
+			.orderBy(tasks.priority, tasks.dueDate)
+			.limit(5),
+		db
+			.select({ title: tasks.title })
+			.from(tasks)
+			.where(and(eq(tasks.userId, userId), ne(tasks.state, 'done')))
+			.orderBy(tasks.dueDate, tasks.priority)
+			.limit(5),
 		db
 			.select({ type: workoutLogs.type, count: sql<number>`count(*)` })
 			.from(workoutLogs)
@@ -370,6 +399,9 @@ async function runDashboardQueries(
 		tasksCompletionRaw,
 		openHighPriorityResult,
 		openTotalResult,
+		dueSoonTasksRaw,
+		openHighPriorityTitlesRaw,
+		openTotalTitlesRaw,
 		workoutTypeBreakdownRaw,
 		allPeopleRaw,
 		allVisitsRaw,
@@ -424,9 +456,11 @@ function buildAgendaCompletionTrend(
 }
 
 function buildTaskStats(
-	completionRaw: { completedAt: string | null }[],
+	completionRaw: { title: string; completedAt: string | null }[],
 	openHighPriorityResult: { count: number }[],
 	openTotalResult: { count: number }[],
+	openHighPriorityTitlesRaw: { title: string }[],
+	openTotalTitlesRaw: { title: string }[],
 	thisWeekDates: string[],
 	lastWeekDates: string[]
 ) {
@@ -434,17 +468,25 @@ function buildTaskStats(
 	const lastWeekDateSet = new Set(lastWeekDates);
 	let completedThisWeek = 0;
 	let completedLastWeek = 0;
+	const completedThisWeekTitles: string[] = [];
 	for (const row of completionRaw) {
 		if (row.completedAt === null) continue;
 		const localDate = getTodayString(new Date(row.completedAt));
-		if (thisWeekDateSet.has(localDate)) completedThisWeek++;
-		else if (lastWeekDateSet.has(localDate)) completedLastWeek++;
+		if (thisWeekDateSet.has(localDate)) {
+			completedThisWeek++;
+			if (completedThisWeekTitles.length < 5) completedThisWeekTitles.push(row.title);
+		} else if (lastWeekDateSet.has(localDate)) {
+			completedLastWeek++;
+		}
 	}
 	return {
 		completedThisWeek,
 		completedLastWeek,
+		completedThisWeekTitles,
 		openHighPriority: Number(openHighPriorityResult[0]?.count || 0),
-		openTotal: Number(openTotalResult[0]?.count || 0)
+		openHighPriorityTitles: openHighPriorityTitlesRaw.map((r) => r.title),
+		openTotal: Number(openTotalResult[0]?.count || 0),
+		openTotalTitles: openTotalTitlesRaw.map((r) => r.title)
 	};
 }
 
@@ -539,6 +581,8 @@ function buildDaysSinceLastWorkout(workouts: { date: string }[], today: string):
 function emptyDashboardReturn() {
 	return {
 		todayLabel: formatTodayLabel(),
+		today: getTodayString(),
+		todayDowIndex: getISODayOfWeek(getTodayString()),
 		stats: {
 			journalThisWeek: 0,
 			journalLastWeek: 0,
@@ -548,7 +592,16 @@ function emptyDashboardReturn() {
 			workoutsLastWeek: 0,
 			workoutsCompletedMonth: 0
 		},
-		taskStats: { completedThisWeek: 0, completedLastWeek: 0, openHighPriority: 0, openTotal: 0 },
+		taskStats: {
+			completedThisWeek: 0,
+			completedLastWeek: 0,
+			completedThisWeekTitles: [] as string[],
+			openHighPriority: 0,
+			openHighPriorityTitles: [] as string[],
+			openTotal: 0,
+			openTotalTitles: [] as string[]
+		},
+		dueSoonTasks: [] as { id: string; title: string; dueDate: string }[],
 		agendaCompletionTrend: [] as { weekLabel: string; completionPct: number }[],
 		workoutTypeBreakdown: [] as { type: string; count: number }[],
 		visitHealthCounts: { critical: 0, overdue: 0, healthy: 0, noVisits: 0, total: 0 },
@@ -608,6 +661,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 		return {
 			todayLabel: formatTodayLabel(),
+			today,
+			todayDowIndex: getISODayOfWeek(today),
 			stats: {
 				journalThisWeek: sumCountsByDate(journalCountByDate, ranges.thisWeekDates),
 				journalLastWeek: sumCountsByDate(journalCountByDate, ranges.lastWeekDates),
@@ -621,9 +676,16 @@ export const load: PageServerLoad = async ({ locals }) => {
 				data.tasksCompletionRaw,
 				data.openHighPriorityResult,
 				data.openTotalResult,
+				data.openHighPriorityTitlesRaw,
+				data.openTotalTitlesRaw,
 				ranges.thisWeekDates,
 				ranges.lastWeekDates
 			),
+			dueSoonTasks: data.dueSoonTasksRaw.map((t) => ({
+				id: t.id,
+				title: t.title,
+				dueDate: t.dueDate as string
+			})),
 			agendaCompletionTrend: buildAgendaCompletionTrend(
 				data.agendaEntriesForTrend,
 				ranges.startOfThisWeekDate

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -5,6 +5,8 @@
 	import VisitHealthPanel from '$lib/components/dashboard/VisitHealthPanel.svelte';
 	import WorkoutTypeChart from '$lib/components/dashboard/WorkoutTypeChart.svelte';
 	import DashboardSkeleton from '$lib/components/skeletons/DashboardSkeleton.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { addDaysToDateString, formatMonthDay } from '$lib/utils/date';
 	import {
 		Book,
 		CalendarCheck,
@@ -59,11 +61,56 @@
 						: 'text-destructive'
 	);
 
+	const tomorrow = $derived(addDaysToDateString(data.today, 1));
+
+	function dueDateLabel(dueDate: string): string {
+		if (dueDate === data.today) return 'Today';
+		if (dueDate === tomorrow) return 'Tomorrow';
+		return formatMonthDay(dueDate);
+	}
+
 	const agendaProgressPct = $derived(
 		data.todayAgendaSummary.total > 0
 			? Math.round((data.todayAgendaSummary.completed / data.todayAgendaSummary.total) * 100)
 			: 0
 	);
+
+	// Weekly meditation goal: 1 session/week, with reminder urgency escalating as the week
+	// progresses without a session (dowIndex: 0 = Monday ... 6 = Sunday).
+	const MEDITATION_WEEKLY_GOAL = 1;
+
+	const meditationGoal = $derived.by(() => {
+		if (data.stats.meditationThisWeek >= MEDITATION_WEEKLY_GOAL) {
+			return {
+				label: 'Weekly goal met',
+				textClass: 'text-[oklch(var(--color-green))]',
+				iconBgClass: 'bg-[oklch(var(--color-green)/0.15)]',
+				iconClass: 'text-[oklch(var(--color-green))]'
+			};
+		}
+		if (data.todayDowIndex <= 2) {
+			return {
+				label: 'Goal: 1 session this week',
+				textClass: 'text-muted-foreground',
+				iconBgClass: 'bg-[oklch(var(--color-purple)/0.15)]',
+				iconClass: 'text-[oklch(var(--color-purple))]'
+			};
+		}
+		if (data.todayDowIndex <= 5) {
+			return {
+				label: "Don't forget your session this week",
+				textClass: 'text-amber-500',
+				iconBgClass: 'bg-amber-500/15',
+				iconClass: 'text-amber-500'
+			};
+		}
+		return {
+			label: 'Last day to hit your weekly goal!',
+			textClass: 'text-destructive',
+			iconBgClass: 'bg-destructive/15',
+			iconClass: 'text-destructive'
+		};
+	});
 
 	const activityConfig = {
 		journal: {
@@ -165,7 +212,10 @@
 			</a>
 
 			<!-- Today's Agenda Summary -->
-			<div class="bg-card rounded-2xl border p-5 shadow-xs md:col-span-2">
+			<a
+				href="/tasks?tab=agenda"
+				class="group bg-card hover:bg-card/80 rounded-2xl border p-5 shadow-xs transition-all hover:-translate-y-0.5 hover:shadow-md md:col-span-2"
+			>
 				<div class="mb-3 flex items-center justify-between">
 					<div class="flex items-center gap-2">
 						<div class="rounded-lg bg-[oklch(var(--color-orange)/0.15)] p-1.5">
@@ -214,7 +264,7 @@
 						{/each}
 					</div>
 				{/if}
-			</div>
+			</a>
 		</div>
 
 		<!-- ── Agenda Analytics ───────────────────────────────────────────────── -->
@@ -280,8 +330,8 @@
 				href="/meditation"
 				class="group bg-card/60 hover:bg-card flex items-center gap-3 rounded-2xl border px-4 py-3.5 transition-colors"
 			>
-				<div class="shrink-0 rounded-lg bg-[oklch(var(--color-purple)/0.15)] p-2">
-					<Heart class="size-4 text-[oklch(var(--color-purple))]" />
+				<div class="shrink-0 rounded-lg p-2 transition-colors {meditationGoal.iconBgClass}">
+					<Heart class="size-4 transition-colors {meditationGoal.iconClass}" />
 				</div>
 				<div class="min-w-0 flex-1">
 					<div class="flex items-center gap-2">
@@ -298,7 +348,9 @@
 							</span>
 						{/if}
 					</div>
-					<p class="text-muted-foreground truncate text-xs">Meditation sessions this week</p>
+					<p class="mt-0.5 truncate text-xs font-medium {meditationGoal.textClass}">
+						{meditationGoal.label}
+					</p>
 				</div>
 			</a>
 		</div>
@@ -331,55 +383,118 @@
 					</div>
 				</div>
 
-				<div class="space-y-4">
-					<div class="flex items-center justify-between">
-						<div class="text-muted-foreground flex items-center gap-2 text-sm">
-							<CircleCheck class="size-4 text-[oklch(var(--color-green))]" />
-							Completed this week
+				<Tooltip.Provider>
+					{#if data.dueSoonTasks.length > 0}
+						<div class="mb-4">
+							<p class="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+								Due soon
+							</p>
+							<div class="space-y-1.5">
+								{#each data.dueSoonTasks as task (task.id)}
+									<a
+										href="/tasks"
+										class="hover:bg-muted/60 flex items-center justify-between gap-2 rounded-lg px-1.5 py-1 text-sm transition-colors"
+									>
+										<span class="truncate">{task.title}</span>
+										<span
+											class="text-muted-foreground shrink-0 text-xs {task.dueDate === data.today
+												? 'font-semibold text-amber-500'
+												: ''}"
+										>
+											{dueDateLabel(task.dueDate)}
+										</span>
+									</a>
+								{/each}
+							</div>
 						</div>
-						<div class="flex items-center gap-2">
-							<span class="font-display text-2xl font-bold tabular-nums">
-								{data.taskStats.completedThisWeek}
-							</span>
-							{#if taskDelta !== null}
-								<span
-									class="rounded-full px-1.5 py-0.5 text-xs font-semibold {taskDelta >= 0
-										? 'bg-[oklch(var(--color-green)/0.15)] text-[oklch(var(--color-green))]'
-										: 'bg-destructive/10 text-destructive'}"
+						<div class="bg-border/60 mb-4 h-px"></div>
+					{/if}
+
+					<div class="space-y-4">
+						<Tooltip.Root>
+							<Tooltip.Trigger class="w-full">
+								{#snippet child({ props })}
+									<div {...props} class="flex items-center justify-between">
+										<div class="text-muted-foreground flex items-center gap-2 text-sm">
+											<CircleCheck class="size-4 text-[oklch(var(--color-green))]" />
+											Completed this week
+										</div>
+										<div class="flex items-center gap-2">
+											<span class="font-display text-2xl font-bold tabular-nums">
+												{data.taskStats.completedThisWeek}
+											</span>
+											{#if taskDelta !== null}
+												<span
+													class="rounded-full px-1.5 py-0.5 text-xs font-semibold {taskDelta >= 0
+														? 'bg-[oklch(var(--color-green)/0.15)] text-[oklch(var(--color-green))]'
+														: 'bg-destructive/10 text-destructive'}"
+												>
+													{taskDelta >= 0 ? '+' : ''}{taskDelta}%
+												</span>
+											{/if}
+										</div>
+									</div>
+								{/snippet}
+							</Tooltip.Trigger>
+							{#if data.taskStats.completedThisWeekTitles.length > 0}
+								<Tooltip.Content
+									>{data.taskStats.completedThisWeekTitles.join(', ')}</Tooltip.Content
 								>
-									{taskDelta >= 0 ? '+' : ''}{taskDelta}%
-								</span>
 							{/if}
+						</Tooltip.Root>
+						<div class="bg-border/60 h-px"></div>
+						<div class="flex items-center justify-between">
+							<span class="text-muted-foreground text-sm">Completed last week</span>
+							<span class="font-display text-muted-foreground text-2xl font-bold tabular-nums">
+								{data.taskStats.completedLastWeek}
+							</span>
 						</div>
+						<div class="bg-border/60 h-px"></div>
+						<Tooltip.Root>
+							<Tooltip.Trigger class="w-full">
+								{#snippet child({ props })}
+									<a
+										href="/tasks"
+										{...props}
+										class="flex items-center justify-between hover:underline"
+									>
+										<div class="text-muted-foreground flex items-center gap-2 text-sm">
+											<CircleAlert class="size-4 text-amber-500" />
+											Open high-priority
+										</div>
+										<span class="font-display text-2xl font-bold text-amber-500 tabular-nums">
+											{data.taskStats.openHighPriority}
+										</span>
+									</a>
+								{/snippet}
+							</Tooltip.Trigger>
+							{#if data.taskStats.openHighPriorityTitles.length > 0}
+								<Tooltip.Content>{data.taskStats.openHighPriorityTitles.join(', ')}</Tooltip.Content
+								>
+							{/if}
+						</Tooltip.Root>
+						<div class="bg-border/60 h-px"></div>
+						<Tooltip.Root>
+							<Tooltip.Trigger class="w-full">
+								{#snippet child({ props })}
+									<a
+										href="/tasks"
+										{...props}
+										class="flex items-center justify-between hover:underline"
+									>
+										<span class="text-muted-foreground text-sm">Open total</span>
+										<span class="font-display text-2xl font-bold tabular-nums">
+											{data.taskStats.openTotal}
+										</span>
+									</a>
+								{/snippet}
+							</Tooltip.Trigger>
+							{#if data.taskStats.openTotalTitles.length > 0}
+								<Tooltip.Content>{data.taskStats.openTotalTitles.join(', ')}</Tooltip.Content>
+							{/if}
+						</Tooltip.Root>
 					</div>
-					<div class="bg-border/60 h-px"></div>
-					<div class="flex items-center justify-between">
-						<span class="text-muted-foreground text-sm">Completed last week</span>
-						<span class="font-display text-muted-foreground text-2xl font-bold tabular-nums">
-							{data.taskStats.completedLastWeek}
-						</span>
-					</div>
-					<div class="bg-border/60 h-px"></div>
-					<div class="flex items-center justify-between">
-						<div class="text-muted-foreground flex items-center gap-2 text-sm">
-							<CircleAlert class="size-4 text-amber-500" />
-							Open high-priority
-						</div>
-						<a
-							href="/tasks"
-							class="font-display text-2xl font-bold text-amber-500 tabular-nums hover:underline"
-						>
-							{data.taskStats.openHighPriority}
-						</a>
-					</div>
-					<div class="bg-border/60 h-px"></div>
-					<div class="flex items-center justify-between">
-						<span class="text-muted-foreground text-sm">Open total</span>
-						<a href="/tasks" class="font-display text-2xl font-bold tabular-nums hover:underline">
-							{data.taskStats.openTotal}
-						</a>
-					</div>
-				</div>
+				</Tooltip.Provider>
 			</div>
 		</div>
 

--- a/src/routes/(app)/dashboard/dashboard-utils.ts
+++ b/src/routes/(app)/dashboard/dashboard-utils.ts
@@ -21,6 +21,7 @@ export type DashboardDateRanges = {
 	upcomingEndDate: string;
 	tasksCompletionRangeStartIso: string;
 	tasksCompletionRangeEndIso: string;
+	dueSoonEndDate: string;
 };
 
 export function buildDateRanges(today: string): DashboardDateRanges {
@@ -40,9 +41,10 @@ export function buildDateRanges(today: string): DashboardDateRanges {
 		agenda8WeeksStart: addDaysToDateString(startOfThisWeekDate, -49),
 		last4WeeksStart: addDaysToDateString(startOfThisWeekDate, -21),
 		workout4WeeksStart: addDaysToDateString(today, -28),
-		upcomingEndDate: addDaysToDateString(today, 7),
+		upcomingEndDate: addDaysToDateString(today, 90),
 		tasksCompletionRangeStartIso: `${addDaysToDateString(startOfLastWeekDate, -1)}T00:00:00.000Z`,
-		tasksCompletionRangeEndIso: `${addDaysToDateString(endOfThisWeekDate, 1)}T00:00:00.000Z`
+		tasksCompletionRangeEndIso: `${addDaysToDateString(endOfThisWeekDate, 1)}T00:00:00.000Z`,
+		dueSoonEndDate: addDaysToDateString(today, 7)
 	};
 }
 


### PR DESCRIPTION
## Summary

Implements the six dashboard widget improvements requested in #282:

- **Today's Agenda** card is now clickable, linking to `/tasks?tab=agenda`
- **Daily Agenda Completion** chart now shows each week's completion % directly on the chart (data labels), not just on hover
- **Meditation Sessions** widget tracks a 1-session/week goal, with reminder wording and color that escalates from a calm Monday reminder to an urgent Sunday warning if the goal isn't met
- **Tasks** widget shows a "Due soon" list (next 7 days) and adds hover tooltips with task titles to the completed/open stat tiles
- **Workout Breakdown** widget now colors the session count and shows a motivational/warning message based on 4-week pace: green (≥12), amber (8–11), red (<8)
- **Visit Health** "Scheduled" list now shows visits up to 90 days out (was 7), in a scrollable container

None of these required a schema or migration change — all underlying data already existed. Filed #298 as a separate follow-up to make the meditation/workout thresholds user-configurable instead of hardcoded, since that would need a new settings table.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` — passes (pre-existing unrelated findings only: unused `logger` export, dev-deps-in-production, untouched by this PR)
- [x] Full test suite (348 tests) — passing
- [x] Manually verified all six changes against real dev data in the browser: Today's Agenda link navigates correctly, per-week % labels render on the completion chart, meditation goal messaging/color is correct for today's day-of-week, due-soon list and tooltips render, workout pace coloring matches thresholds, Visit Health scheduled list widened

🤖 Generated with [Claude Code](https://claude.com/claude-code)