### PR TITLE
feat: make dashboard goal thresholds user-configurable

### DIFF
--- a/src/lib/components/dashboard/WorkoutTypeChart.svelte
+++ b/src/lib/components/dashboard/WorkoutTypeChart.svelte
@@ -8,7 +8,15 @@
 		count: number;
 	}
 
-	let { breakdown }: { breakdown: WorkoutTypeCount[] } = $props();
+	let {
+		breakdown,
+		greenThreshold,
+		amberThreshold
+	}: {
+		breakdown: WorkoutTypeCount[];
+		greenThreshold: number;
+		amberThreshold: number;
+	} = $props();
 
 	const chartConfig = {
 		count: { label: 'Sessions' }
@@ -23,20 +31,20 @@
 
 	const totalSessions = $derived(breakdown.reduce((sum, d) => sum + d.count, 0));
 
-	// Thresholds are per the dashboard goal of ~3 workouts/week over the trailing 4 weeks.
+	// Thresholds come from the user's dashboard goal settings.
 	const workoutPace = $derived.by(() => {
-		if (totalSessions >= 12) {
+		if (totalSessions >= greenThreshold) {
 			return {
 				textClass: 'text-[oklch(var(--color-green))]',
 				barColor: 'oklch(var(--color-green))',
-				message: "Great pace — you're hitting 3+ workouts a week."
+				message: `Great pace — you're hitting ${greenThreshold}+ workouts every 4 weeks.`
 			};
 		}
-		if (totalSessions >= 8) {
+		if (totalSessions >= amberThreshold) {
 			return {
 				textClass: 'text-amber-500',
 				barColor: '#f59e0b',
-				message: 'Below pace — aim for 3 workouts a week to catch up.'
+				message: `Below pace — aim for ${greenThreshold} workouts every 4 weeks to catch up.`
 			};
 		}
 		return {

--- a/src/lib/schemas/auth.test.ts
+++ b/src/lib/schemas/auth.test.ts
@@ -6,6 +6,7 @@ import {
 	loginSchema,
 	registerSchema,
 	resetPasswordSchema,
+	updateDashboardGoalSettingsSchema,
 	updateProfileSchema
 } from './auth';
 
@@ -170,6 +171,59 @@ describe('changePasswordSchema', () => {
 			currentPassword: 'OldPass123456',
 			newPassword: 'NewPass12345!',
 			confirmPassword: 'Different123!'
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('updateDashboardGoalSettingsSchema', () => {
+	const validPayload = {
+		meditationWeeklyGoal: 2,
+		workoutGreenThreshold: 12,
+		workoutAmberThreshold: 8
+	};
+
+	it('accepts a valid payload', () => {
+		expect(() => updateDashboardGoalSettingsSchema.parse(validPayload)).not.toThrow();
+	});
+
+	it('rejects a non-positive meditation weekly goal', () => {
+		const result = updateDashboardGoalSettingsSchema.safeParse({
+			...validPayload,
+			meditationWeeklyGoal: 0
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a non-positive green threshold', () => {
+		const result = updateDashboardGoalSettingsSchema.safeParse({
+			...validPayload,
+			workoutGreenThreshold: 0
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts a zero amber threshold', () => {
+		const result = updateDashboardGoalSettingsSchema.safeParse({
+			...validPayload,
+			workoutAmberThreshold: 0
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a negative amber threshold', () => {
+		const result = updateDashboardGoalSettingsSchema.safeParse({
+			...validPayload,
+			workoutAmberThreshold: -1
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects when amber threshold is not less than green threshold', () => {
+		const result = updateDashboardGoalSettingsSchema.safeParse({
+			...validPayload,
+			workoutGreenThreshold: 8,
+			workoutAmberThreshold: 8
 		});
 		expect(result.success).toBe(false);
 	});

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -84,6 +84,26 @@ export const updateVisitStatusSettingsSchema = z
 		}
 	);
 
+export const updateDashboardGoalSettingsSchema = z
+	.object({
+		meditationWeeklyGoal: z.coerce
+			.number()
+			.int('Must be a whole number')
+			.positive('Value must be greater than 0'),
+		workoutGreenThreshold: z.coerce
+			.number()
+			.int('Must be a whole number')
+			.positive('Value must be greater than 0'),
+		workoutAmberThreshold: z.coerce
+			.number()
+			.int('Must be a whole number')
+			.nonnegative('Value must be 0 or greater')
+	})
+	.refine((data) => data.workoutGreenThreshold > data.workoutAmberThreshold, {
+		path: ['workoutAmberThreshold'],
+		message: 'Amber threshold must be less than the green threshold'
+	});
+
 export const changePasswordSchema = z
 	.object({
 		currentPassword: z.string().min(1, 'Current password is required'),

--- a/src/lib/server/dashboard-goal-settings.ts
+++ b/src/lib/server/dashboard-goal-settings.ts
@@ -1,0 +1,39 @@
+import { getDb } from '$lib/server/db';
+import { dashboardGoalSettings } from '$lib/server/db/schema';
+import {
+	DEFAULT_DASHBOARD_GOALS,
+	normalizeDashboardGoals,
+	type DashboardGoals
+} from '$lib/utils/dashboard-goals';
+import { eq } from 'drizzle-orm';
+
+function toGoals(
+	row:
+		| {
+				meditationWeeklyGoal: number;
+				workoutGreenThreshold: number;
+				workoutAmberThreshold: number;
+		  }
+		| undefined
+): DashboardGoals {
+	if (!row) {
+		return { ...DEFAULT_DASHBOARD_GOALS };
+	}
+
+	return normalizeDashboardGoals({
+		meditationWeeklyGoal: row.meditationWeeklyGoal,
+		workoutGreenThreshold: row.workoutGreenThreshold,
+		workoutAmberThreshold: row.workoutAmberThreshold
+	});
+}
+
+export async function getDashboardGoalsForUser(
+	userId: string,
+	db = getDb()
+): Promise<DashboardGoals> {
+	const settings = await db.query.dashboardGoalSettings.findFirst({
+		where: eq(dashboardGoalSettings.userId, userId)
+	});
+
+	return toGoals(settings);
+}

--- a/src/lib/server/db/migrations/0023_spooky_jack_flag.sql
+++ b/src/lib/server/db/migrations/0023_spooky_jack_flag.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `dashboard_goal_settings` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`meditation_weekly_goal` integer NOT NULL,
+	`workout_green_threshold` integer NOT NULL,
+	`workout_amber_threshold` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `dashboard_goal_settings_user_id_unique` ON `dashboard_goal_settings` (`user_id`);

--- a/src/lib/server/db/migrations/meta/0023_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,2070 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "ce9554b9-862e-49db-b5f6-3551a7bfdd46",
+	"prevId": "8672d5cf-ccee-4b42-a440-2662a7c87355",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshTokenUpdatedAt": {
+					"name": "refreshTokenUpdatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_entries": {
+			"name": "daily_agenda_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"completed": {
+					"name": "completed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_entries_user_date_idx": {
+					"name": "daily_agenda_entries_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_group_date_idx": {
+					"name": "daily_agenda_entries_group_date_idx",
+					"columns": ["template_group_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_default_unique_idx": {
+					"name": "daily_agenda_entries_default_unique_idx",
+					"columns": ["user_id", "template_group_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_entries_user_id_user_id_fk": {
+					"name": "daily_agenda_entries_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"daily_agenda_entries_template_id_daily_agenda_templates_id_fk": {
+					"name": "daily_agenda_entries_template_id_daily_agenda_templates_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "daily_agenda_templates",
+					"columnsFrom": ["template_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_templates": {
+			"name": "daily_agenda_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[0,1,2,3,4,5,6]'"
+				},
+				"starts_on": {
+					"name": "starts_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ends_on": {
+					"name": "ends_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_templates_user_range_idx": {
+					"name": "daily_agenda_templates_user_range_idx",
+					"columns": ["user_id", "starts_on", "ends_on"],
+					"isUnique": false
+				},
+				"daily_agenda_templates_group_idx": {
+					"name": "daily_agenda_templates_group_idx",
+					"columns": ["template_group_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_templates_user_id_user_id_fk": {
+					"name": "daily_agenda_templates_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_templates",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_calorie_targets": {
+			"name": "daily_calorie_targets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_calories": {
+					"name": "target_calories",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_calorie_targets_user_id_unique": {
+					"name": "daily_calorie_targets_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_calorie_targets_user_id_user_id_fk": {
+					"name": "daily_calorie_targets_user_id_user_id_fk",
+					"tableFrom": "daily_calorie_targets",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"dashboard_goal_settings": {
+			"name": "dashboard_goal_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"meditation_weekly_goal": {
+					"name": "meditation_weekly_goal",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_green_threshold": {
+					"name": "workout_green_threshold",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_amber_threshold": {
+					"name": "workout_amber_threshold",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"dashboard_goal_settings_user_id_unique": {
+					"name": "dashboard_goal_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"dashboard_goal_settings_user_id_user_id_fk": {
+					"name": "dashboard_goal_settings_user_id_user_id_fk",
+					"tableFrom": "dashboard_goal_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_notifications": {
+			"name": "email_notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notification_type": {
+					"name": "notification_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_subject": {
+					"name": "email_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_notifications_userId_user_id_fk": {
+					"name": "email_notifications_userId_user_id_fk",
+					"tableFrom": "email_notifications",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"goal_weights": {
+			"name": "goal_weights",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_weight_lbs": {
+					"name": "target_weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"goal_weights_user_id_unique": {
+					"name": "goal_weights_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"goal_weights_user_id_user_id_fk": {
+					"name": "goal_weights_user_id_user_id_fk",
+					"tableFrom": "goal_weights",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"journal_entries": {
+			"name": "journal_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weather": {
+					"name": "weather",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"journal_entries_user_id_user_id_fk": {
+					"name": "journal_entries_user_id_user_id_fk",
+					"tableFrom": "journal_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meal_logs": {
+			"name": "meal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time_of_day": {
+					"name": "time_of_day",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"calories_estimate": {
+					"name": "calories_estimate",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meal_logs_user_id_user_id_fk": {
+					"name": "meal_logs_user_id_user_id_fk",
+					"tableFrom": "meal_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_routines": {
+			"name": "meditation_routines",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"link_url": {
+					"name": "link_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood_tags": {
+					"name": "mood_tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_predefined": {
+					"name": "is_predefined",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_routines_user_id_user_id_fk": {
+					"name": "meditation_routines_user_id_user_id_fk",
+					"tableFrom": "meditation_routines",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_schedules": {
+			"name": "meditation_schedules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_schedules_user_id_user_id_fk": {
+					"name": "meditation_schedules_user_id_user_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_schedules_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_schedules_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_sessions": {
+			"name": "meditation_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pre_mood_rating": {
+					"name": "pre_mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mood_rating": {
+					"name": "mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_sessions_user_id_user_id_fk": {
+					"name": "meditation_sessions_user_id_user_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_sessions_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_sessions_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mood_logs": {
+			"name": "mood_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood": {
+					"name": "mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"custom_mood": {
+					"name": "custom_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mood_logs_user_date_idx": {
+					"name": "mood_logs_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"mood_logs_user_date_unique_idx": {
+					"name": "mood_logs_user_date_unique_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"mood_logs_user_id_user_id_fk": {
+					"name": "mood_logs_user_id_user_id_fk",
+					"tableFrom": "mood_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"people": {
+			"name": "people",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_exempt": {
+					"name": "is_exempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scheduled_visit_date": {
+					"name": "scheduled_visit_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"people_user_id_user_id_fk": {
+					"name": "people_user_id_user_id_fk",
+					"tableFrom": "people",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tasks": {
+			"name": "tasks",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"task_number": {
+					"name": "task_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_date": {
+					"name": "due_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'new'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tasks_task_number_unique": {
+					"name": "tasks_task_number_unique",
+					"columns": ["task_number"],
+					"isUnique": true
+				},
+				"tasks_user_state_sort_idx": {
+					"name": "tasks_user_state_sort_idx",
+					"columns": ["user_id", "state", "sort_order"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tasks_user_id_user_id_fk": {
+					"name": "tasks_user_id_user_id_fk",
+					"tableFrom": "tasks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visit_status_settings": {
+			"name": "visit_status_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recent_to_overdue_days": {
+					"name": "recent_to_overdue_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"overdue_to_critical_days": {
+					"name": "overdue_to_critical_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"visit_status_settings_user_id_unique": {
+					"name": "visit_status_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"visit_status_settings_user_id_user_id_fk": {
+					"name": "visit_status_settings_user_id_user_id_fk",
+					"tableFrom": "visit_status_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visits": {
+			"name": "visits",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"person_id": {
+					"name": "person_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"companions": {
+					"name": "companions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"follow_up_date": {
+					"name": "follow_up_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"visits_person_id_people_id_fk": {
+					"name": "visits_person_id_people_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "people",
+					"columnsFrom": ["person_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"visits_user_id_user_id_fk": {
+					"name": "visits_user_id_user_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"weight_entries": {
+			"name": "weight_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"weight_entries_user_id_user_id_fk": {
+					"name": "weight_entries_user_id_user_id_fk",
+					"tableFrom": "weight_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_exercises": {
+			"name": "workout_exercises",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_log_id": {
+					"name": "workout_log_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exercise_name": {
+					"name": "exercise_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sets": {
+					"name": "sets",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reps": {
+					"name": "reps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_exercises_workout_log_id_workout_logs_id_fk": {
+					"name": "workout_exercises_workout_log_id_workout_logs_id_fk",
+					"tableFrom": "workout_exercises",
+					"tableTo": "workout_logs",
+					"columnsFrom": ["workout_log_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_logs": {
+			"name": "workout_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"steps": {
+					"name": "steps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_logs_user_id_user_id_fk": {
+					"name": "workout_logs_user_id_user_id_fk",
+					"tableFrom": "workout_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_reminders": {
+			"name": "workout_reminders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_type": {
+					"name": "workout_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_reminders_user_id_user_id_fk": {
+					"name": "workout_reminders_user_id_user_id_fk",
+					"tableFrom": "workout_reminders",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
 			"when": 1785714523498,
 			"tag": "0022_rich_komodo",
 			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "6",
+			"when": 1785819982487,
+			"tag": "0023_spooky_jack_flag",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -700,3 +700,32 @@ export const visitStatusSettingsRelations = relations(visitStatusSettings, ({ on
 		references: [user.id]
 	})
 }));
+
+/**
+ * Dashboard Goal Settings
+ * Per-user thresholds for dashboard widget goals (meditation weekly goal,
+ * workout pace thresholds over a trailing 4-week window).
+ */
+export const dashboardGoalSettings = sqliteTable('dashboard_goal_settings', {
+	id: text('id').primaryKey().$defaultFn(generateId),
+	userId: text('user_id')
+		.notNull()
+		.unique()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	meditationWeeklyGoal: integer('meditation_weekly_goal').notNull(),
+	workoutGreenThreshold: integer('workout_green_threshold').notNull(),
+	workoutAmberThreshold: integer('workout_amber_threshold').notNull(),
+	createdAt: text('created_at')
+		.notNull()
+		.$defaultFn(() => new Date().toISOString()),
+	updatedAt: text('updated_at')
+		.notNull()
+		.$defaultFn(() => new Date().toISOString())
+});
+
+export const dashboardGoalSettingsRelations = relations(dashboardGoalSettings, ({ one }) => ({
+	user: one(user, {
+		fields: [dashboardGoalSettings.userId],
+		references: [user.id]
+	})
+}));

--- a/src/lib/utils/dashboard-goals.test.ts
+++ b/src/lib/utils/dashboard-goals.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_DASHBOARD_GOALS, normalizeDashboardGoals } from './dashboard-goals';
+
+describe('dashboard goal normalization', () => {
+	it('returns defaults when no goals are provided', () => {
+		expect(normalizeDashboardGoals()).toEqual(DEFAULT_DASHBOARD_GOALS);
+		expect(normalizeDashboardGoals(null)).toEqual(DEFAULT_DASHBOARD_GOALS);
+	});
+
+	it('accepts valid custom goals', () => {
+		expect(
+			normalizeDashboardGoals({
+				meditationWeeklyGoal: 3,
+				workoutGreenThreshold: 16,
+				workoutAmberThreshold: 10
+			})
+		).toEqual({
+			meditationWeeklyGoal: 3,
+			workoutGreenThreshold: 16,
+			workoutAmberThreshold: 10
+		});
+	});
+
+	it('allows a zero amber threshold', () => {
+		expect(
+			normalizeDashboardGoals({
+				meditationWeeklyGoal: 1,
+				workoutGreenThreshold: 5,
+				workoutAmberThreshold: 0
+			})
+		).toEqual({
+			meditationWeeklyGoal: 1,
+			workoutGreenThreshold: 5,
+			workoutAmberThreshold: 0
+		});
+	});
+
+	it('falls back to defaults when amber threshold is not less than green threshold', () => {
+		expect(
+			normalizeDashboardGoals({
+				meditationWeeklyGoal: 2,
+				workoutGreenThreshold: 8,
+				workoutAmberThreshold: 8
+			})
+		).toEqual(DEFAULT_DASHBOARD_GOALS);
+
+		expect(
+			normalizeDashboardGoals({
+				meditationWeeklyGoal: 2,
+				workoutGreenThreshold: 8,
+				workoutAmberThreshold: 10
+			})
+		).toEqual(DEFAULT_DASHBOARD_GOALS);
+	});
+
+	it('falls back to defaults for invalid individual values', () => {
+		expect(normalizeDashboardGoals({ meditationWeeklyGoal: 0 }).meditationWeeklyGoal).toBe(
+			DEFAULT_DASHBOARD_GOALS.meditationWeeklyGoal
+		);
+		expect(normalizeDashboardGoals({ meditationWeeklyGoal: -1 }).meditationWeeklyGoal).toBe(
+			DEFAULT_DASHBOARD_GOALS.meditationWeeklyGoal
+		);
+		expect(
+			normalizeDashboardGoals({ workoutGreenThreshold: Number.NaN }).workoutGreenThreshold
+		).toBe(DEFAULT_DASHBOARD_GOALS.workoutGreenThreshold);
+		expect(normalizeDashboardGoals({ workoutAmberThreshold: -1 }).workoutAmberThreshold).toBe(
+			DEFAULT_DASHBOARD_GOALS.workoutAmberThreshold
+		);
+	});
+
+	it('rounds non-integer values', () => {
+		expect(
+			normalizeDashboardGoals({
+				meditationWeeklyGoal: 2.4,
+				workoutGreenThreshold: 12.6,
+				workoutAmberThreshold: 7.5
+			})
+		).toEqual({
+			meditationWeeklyGoal: 2,
+			workoutGreenThreshold: 13,
+			workoutAmberThreshold: 8
+		});
+	});
+});

--- a/src/lib/utils/dashboard-goals.ts
+++ b/src/lib/utils/dashboard-goals.ts
@@ -1,0 +1,45 @@
+export interface DashboardGoals {
+	meditationWeeklyGoal: number;
+	workoutGreenThreshold: number;
+	workoutAmberThreshold: number;
+}
+
+export const DEFAULT_DASHBOARD_GOALS: DashboardGoals = {
+	meditationWeeklyGoal: 1,
+	workoutGreenThreshold: 12,
+	workoutAmberThreshold: 8
+};
+
+function isPositiveInteger(value: number): boolean {
+	return Number.isInteger(value) && Number.isFinite(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: number): boolean {
+	return Number.isInteger(value) && Number.isFinite(value) && value >= 0;
+}
+
+export function normalizeDashboardGoals(goals?: Partial<DashboardGoals> | null): DashboardGoals {
+	const meditationCandidate = Math.round(Number(goals?.meditationWeeklyGoal));
+	const greenCandidate = Math.round(Number(goals?.workoutGreenThreshold));
+	const amberCandidate = Math.round(Number(goals?.workoutAmberThreshold));
+
+	const meditationWeeklyGoal = isPositiveInteger(meditationCandidate)
+		? meditationCandidate
+		: DEFAULT_DASHBOARD_GOALS.meditationWeeklyGoal;
+	const workoutGreenThreshold = isPositiveInteger(greenCandidate)
+		? greenCandidate
+		: DEFAULT_DASHBOARD_GOALS.workoutGreenThreshold;
+	const workoutAmberThreshold = isNonNegativeInteger(amberCandidate)
+		? amberCandidate
+		: DEFAULT_DASHBOARD_GOALS.workoutAmberThreshold;
+
+	if (workoutAmberThreshold >= workoutGreenThreshold) {
+		return { ...DEFAULT_DASHBOARD_GOALS };
+	}
+
+	return {
+		meditationWeeklyGoal,
+		workoutGreenThreshold,
+		workoutAmberThreshold
+	};
+}

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -1,5 +1,6 @@
 import { logger } from '$lib';
 import { getUser } from '$lib/server/actions/auth-guard';
+import { getDashboardGoalsForUser } from '$lib/server/dashboard-goal-settings';
 import { getDb } from '$lib/server/db';
 import {
 	dailyAgendaEntries,
@@ -11,6 +12,7 @@ import {
 	workoutLogs
 } from '$lib/server/db/schema';
 import { getVisitStatusThresholdsForUser } from '$lib/server/visit-status-settings';
+import { DEFAULT_DASHBOARD_GOALS } from '$lib/utils/dashboard-goals';
 import {
 	addDaysToDateString,
 	calendarDaysBetween,
@@ -625,7 +627,8 @@ function emptyDashboardReturn() {
 			completed: 0,
 			total: 0,
 			items: [] as { id: string; title: string; completed: boolean }[]
-		}
+		},
+		dashboardGoals: DEFAULT_DASHBOARD_GOALS
 	};
 }
 
@@ -637,9 +640,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const db = getDb();
 
 	try {
-		const [data, visitStatusThresholds] = await Promise.all([
+		const [data, visitStatusThresholds, dashboardGoals] = await Promise.all([
 			runDashboardQueries(db, user.id, ranges),
-			getVisitStatusThresholdsForUser(user.id, db)
+			getVisitStatusThresholdsForUser(user.id, db),
+			getDashboardGoalsForUser(user.id, db)
 		]);
 
 		const journalCountByDate = buildCountByDateMap(data.journalDateCounts);
@@ -706,7 +710,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 			recentActivity: buildActivityFeed(data),
 			agendaItemStats: buildAgendaItemStats(data.agendaEntriesForTrend, ranges),
 			daysSinceLastWorkout: buildDaysSinceLastWorkout(data.recentWorkoutRaw, today),
-			todayAgendaSummary: buildTodayAgendaSummary(data.agendaEntriesForTrend, today)
+			todayAgendaSummary: buildTodayAgendaSummary(data.agendaEntriesForTrend, today),
+			dashboardGoals
 		};
 	} catch (error) {
 		logger.error('Failed to load dashboard data', error);

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -75,12 +75,12 @@
 			: 0
 	);
 
-	// Weekly meditation goal: 1 session/week, with reminder urgency escalating as the week
-	// progresses without a session (dowIndex: 0 = Monday ... 6 = Sunday).
-	const MEDITATION_WEEKLY_GOAL = 1;
+	// Weekly meditation goal, with reminder urgency escalating as the week
+	// progresses without hitting it (dowIndex: 0 = Monday ... 6 = Sunday).
+	const meditationWeeklyGoal = $derived(data.dashboardGoals.meditationWeeklyGoal);
 
 	const meditationGoal = $derived.by(() => {
-		if (data.stats.meditationThisWeek >= MEDITATION_WEEKLY_GOAL) {
+		if (data.stats.meditationThisWeek >= meditationWeeklyGoal) {
 			return {
 				label: 'Weekly goal met',
 				textClass: 'text-[oklch(var(--color-green))]',
@@ -90,7 +90,7 @@
 		}
 		if (data.todayDowIndex <= 2) {
 			return {
-				label: 'Goal: 1 session this week',
+				label: `Goal: ${meditationWeeklyGoal} session${meditationWeeklyGoal === 1 ? '' : 's'} this week`,
 				textClass: 'text-muted-foreground',
 				iconBgClass: 'bg-[oklch(var(--color-purple)/0.15)]',
 				iconClass: 'text-[oklch(var(--color-purple))]'
@@ -368,7 +368,11 @@
 						<p class="text-muted-foreground text-xs">By type, last 4 weeks</p>
 					</div>
 				</div>
-				<WorkoutTypeChart breakdown={data.workoutTypeBreakdown} />
+				<WorkoutTypeChart
+					breakdown={data.workoutTypeBreakdown}
+					greenThreshold={data.dashboardGoals.workoutGreenThreshold}
+					amberThreshold={data.dashboardGoals.workoutAmberThreshold}
+				/>
 			</div>
 
 			<!-- Task Stats -->

--- a/src/routes/(app)/profile/+page.server.ts
+++ b/src/routes/(app)/profile/+page.server.ts
@@ -1,19 +1,22 @@
 import { logger } from '$lib';
 import {
 	changePasswordSchema,
+	updateDashboardGoalSettingsSchema,
 	updateProfileSchema,
 	updateVisitStatusSettingsSchema
 } from '$lib/schemas/auth';
 import { getUser, requireAuth } from '$lib/server/actions/auth-guard';
 import { auth } from '$lib/server/auth';
+import { getDashboardGoalsForUser } from '$lib/server/dashboard-goal-settings';
 import { getDb } from '$lib/server/db';
-import { account, user, visitStatusSettings } from '$lib/server/db/schema';
+import { account, dashboardGoalSettings, user, visitStatusSettings } from '$lib/server/db/schema';
 import {
 	generateId,
 	withAuditFieldsForCreate,
 	withAuditFieldsForUpdate
 } from '$lib/server/db/utils';
 import { getVisitStatusThresholdsForUser } from '$lib/server/visit-status-settings';
+import { DEFAULT_DASHBOARD_GOALS, normalizeDashboardGoals } from '$lib/utils/dashboard-goals';
 import {
 	convertVisitThresholdToDays,
 	DEFAULT_VISIT_STATUS_THRESHOLDS,
@@ -30,10 +33,11 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const userId = getUser(locals).id;
 
 	try {
-		const [fullUserData, accountData, visitThresholds] = await Promise.all([
+		const [fullUserData, accountData, visitThresholds, dashboardGoals] = await Promise.all([
 			db.query.user.findFirst({ where: eq(user.id, userId) }),
 			db.query.account.findFirst({ where: eq(account.userId, userId) }),
-			getVisitStatusThresholdsForUser(userId, db)
+			getVisitStatusThresholdsForUser(userId, db),
+			getDashboardGoalsForUser(userId, db)
 		]);
 
 		// Initialize profile form with current user data
@@ -50,6 +54,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 			},
 			zod4(updateVisitStatusSettingsSchema)
 		);
+		const dashboardGoalSettingsForm = await superValidate(
+			dashboardGoals,
+			zod4(updateDashboardGoalSettingsSchema)
+		);
 
 		return {
 			user: fullUserData || locals.user,
@@ -57,6 +65,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 			passwordForm,
 			visitSettingsForm,
 			visitThresholds,
+			dashboardGoalSettingsForm,
+			dashboardGoals,
 			passwordUpdatedAt: accountData?.updatedAt || null
 		};
 	} catch (err) {
@@ -68,6 +78,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 			passwordForm: await superValidate(zod4(changePasswordSchema)),
 			visitSettingsForm: await superValidate(zod4(updateVisitStatusSettingsSchema)),
 			visitThresholds: DEFAULT_VISIT_STATUS_THRESHOLDS,
+			dashboardGoalSettingsForm: await superValidate(zod4(updateDashboardGoalSettingsSchema)),
+			dashboardGoals: DEFAULT_DASHBOARD_GOALS,
 			passwordUpdatedAt: null
 		};
 	}
@@ -201,6 +213,61 @@ export const actions = {
 			return message(
 				form,
 				{ type: 'error', text: 'Failed to update visit settings. Please try again.' },
+				{ status: 500 }
+			);
+		}
+	}),
+
+	updateDashboardGoalSettings: requireAuth(async ({ request }, currentUser) => {
+		const form = await superValidate(request, zod4(updateDashboardGoalSettingsSchema));
+
+		if (!form.valid) {
+			return message(
+				form,
+				{ type: 'error', text: 'Please correct the errors in the form.' },
+				{ status: 400 }
+			);
+		}
+
+		try {
+			const db = getDb();
+			const normalizedGoals = normalizeDashboardGoals(form.data);
+
+			const existing = await db.query.dashboardGoalSettings.findFirst({
+				where: eq(dashboardGoalSettings.userId, currentUser.id)
+			});
+
+			if (existing) {
+				await db
+					.update(dashboardGoalSettings)
+					.set({
+						...normalizedGoals,
+						...withAuditFieldsForUpdate()
+					})
+					.where(eq(dashboardGoalSettings.userId, currentUser.id));
+			} else {
+				await db.insert(dashboardGoalSettings).values({
+					id: generateId(),
+					userId: currentUser.id,
+					...normalizedGoals,
+					...withAuditFieldsForCreate()
+				});
+			}
+
+			logger.info('Dashboard goal settings updated', {
+				userId: currentUser.id,
+				...normalizedGoals
+			});
+
+			return message(form, {
+				type: 'success',
+				text: 'Dashboard goals updated successfully.'
+			});
+		} catch (error) {
+			logger.error('Failed to update dashboard goal settings', error);
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to update dashboard goals. Please try again.' },
 				{ status: 500 }
 			);
 		}

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -10,6 +10,7 @@
 	import {
 		CircleAlert,
 		CircleCheck,
+		Gauge,
 		Lock,
 		Pencil,
 		Save,
@@ -104,10 +105,28 @@
 		submitting: visitSettingsSubmitting
 	} = visitSettingsFormStore;
 
+	// Dashboard goal settings form
+	// svelte-ignore state_referenced_locally
+	const dashboardGoalSettingsFormStore = superForm(data.dashboardGoalSettingsForm, {
+		onUpdate: ({ form }) => {
+			if (isSuccessMessage(form.message as FormMessage)) {
+				isEditingDashboardGoals = false;
+			}
+		}
+	});
+
+	const {
+		form: dashboardGoalSettingsForm,
+		errors: dashboardGoalSettingsErrors,
+		message: dashboardGoalSettingsMessage,
+		submitting: dashboardGoalSettingsSubmitting
+	} = dashboardGoalSettingsFormStore;
+
 	// Profile editing state
 	let isEditingProfile = $state(false);
 	let isEditingPassword = $state(false);
 	let isEditingVisitSettings = $state(false);
+	let isEditingDashboardGoals = $state(false);
 
 	// Derived values from data
 	const userEmail = $derived(data.user?.email || '');
@@ -162,6 +181,13 @@
 		$visitSettingsForm.recentToOverdueValue = data.visitThresholds.recentToOverdueDays;
 		$visitSettingsForm.overdueToCriticalValue = data.visitThresholds.overdueToCriticalDays;
 		isEditingVisitSettings = false;
+	}
+
+	function resetDashboardGoalSettingsForm() {
+		$dashboardGoalSettingsForm.meditationWeeklyGoal = data.dashboardGoals.meditationWeeklyGoal;
+		$dashboardGoalSettingsForm.workoutGreenThreshold = data.dashboardGoals.workoutGreenThreshold;
+		$dashboardGoalSettingsForm.workoutAmberThreshold = data.dashboardGoals.workoutAmberThreshold;
+		isEditingDashboardGoals = false;
 	}
 
 	const visitThresholdSummary = $derived.by(() => {
@@ -445,6 +471,176 @@
 											data.visitThresholds.overdueToCriticalDays,
 											'months'
 										)} months)
+									</strong>
+								</p>
+							</div>
+						{/if}
+					</div>
+				</form>
+			</div>
+		</div>
+
+		<Separator.Root />
+
+		<!-- Dashboard Goal Settings Section -->
+		<div class="overflow-hidden rounded-lg border shadow">
+			<div class="p-6">
+				<div class="mb-4 flex items-center justify-between">
+					<div class="flex items-center gap-2">
+						<Gauge class="h-5 w-5" />
+						<h2 class="text-xl font-semibold">Dashboard Goals</h2>
+					</div>
+					{#if !isEditingDashboardGoals}
+						<Button size="sm" variant="outline" onclick={() => (isEditingDashboardGoals = true)}>
+							<Pencil class="mr-2 h-4 w-4" />
+							Edit
+						</Button>
+					{/if}
+				</div>
+
+				<form method="POST" action="?/updateDashboardGoalSettings">
+					<div class="space-y-4">
+						{#if $dashboardGoalSettingsMessage}
+							<div
+								class="flex items-center gap-2 rounded-md p-3 {isSuccessMessage(
+									$dashboardGoalSettingsMessage
+								)
+									? 'border border-green-200 bg-green-50 text-green-700'
+									: 'border border-red-200 bg-red-50 text-red-700'}"
+							>
+								{#if isSuccessMessage($dashboardGoalSettingsMessage)}
+									<CircleCheck class="h-4 w-4" />
+								{:else}
+									<CircleAlert class="h-4 w-4" />
+								{/if}
+								<span class="text-sm">{getMessageText($dashboardGoalSettingsMessage)}</span>
+							</div>
+						{/if}
+
+						{#if isEditingDashboardGoals}
+							<div class="space-y-4">
+								<p class="text-muted-foreground text-sm">
+									Customize the meditation weekly goal and the workout pace thresholds shown on your
+									dashboard.
+								</p>
+
+								<div>
+									<Label for="meditationWeeklyGoal" class="mb-2 block text-sm font-medium">
+										Meditation weekly goal (sessions/week)
+									</Label>
+									<Input
+										id="meditationWeeklyGoal"
+										name="meditationWeeklyGoal"
+										type="number"
+										step="1"
+										min="1"
+										bind:value={$dashboardGoalSettingsForm.meditationWeeklyGoal}
+										class={$dashboardGoalSettingsErrors.meditationWeeklyGoal
+											? 'border-red-400'
+											: ''}
+										required
+									/>
+									{#if $dashboardGoalSettingsErrors.meditationWeeklyGoal}
+										<p class="mt-1 text-sm text-red-600">
+											{$dashboardGoalSettingsErrors.meditationWeeklyGoal}
+										</p>
+									{/if}
+								</div>
+
+								<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+									<div>
+										<Label for="workoutGreenThreshold" class="mb-2 block text-sm font-medium">
+											On-pace threshold (sessions/4 weeks)
+										</Label>
+										<Input
+											id="workoutGreenThreshold"
+											name="workoutGreenThreshold"
+											type="number"
+											step="1"
+											min="1"
+											bind:value={$dashboardGoalSettingsForm.workoutGreenThreshold}
+											class={$dashboardGoalSettingsErrors.workoutGreenThreshold
+												? 'border-red-400'
+												: ''}
+											required
+										/>
+										{#if $dashboardGoalSettingsErrors.workoutGreenThreshold}
+											<p class="mt-1 text-sm text-red-600">
+												{$dashboardGoalSettingsErrors.workoutGreenThreshold}
+											</p>
+										{/if}
+									</div>
+
+									<div>
+										<Label for="workoutAmberThreshold" class="mb-2 block text-sm font-medium">
+											Below-pace threshold (sessions/4 weeks)
+										</Label>
+										<Input
+											id="workoutAmberThreshold"
+											name="workoutAmberThreshold"
+											type="number"
+											step="1"
+											min="0"
+											bind:value={$dashboardGoalSettingsForm.workoutAmberThreshold}
+											class={$dashboardGoalSettingsErrors.workoutAmberThreshold
+												? 'border-red-400'
+												: ''}
+											required
+										/>
+										{#if $dashboardGoalSettingsErrors.workoutAmberThreshold}
+											<p class="mt-1 text-sm text-red-600">
+												{$dashboardGoalSettingsErrors.workoutAmberThreshold}
+											</p>
+										{/if}
+									</div>
+								</div>
+
+								<p class="text-muted-foreground text-xs">
+									At or above the on-pace threshold shows green, below it shows amber, and at or
+									below the below-pace threshold shows red.
+								</p>
+
+								<div class="flex gap-2 pt-2">
+									<Button type="submit" size="sm" disabled={$dashboardGoalSettingsSubmitting}>
+										{#if $dashboardGoalSettingsSubmitting}
+											<div
+												class="border-primary mr-2 h-4 w-4 animate-spin rounded-full border-2 border-t-transparent"
+											></div>
+										{:else}
+											<Save class="mr-2 h-4 w-4" />
+										{/if}
+										Save
+									</Button>
+									<Button
+										type="button"
+										size="sm"
+										variant="outline"
+										onclick={resetDashboardGoalSettingsForm}
+										disabled={$dashboardGoalSettingsSubmitting}
+									>
+										<X class="mr-2 h-4 w-4" />
+										Cancel
+									</Button>
+								</div>
+							</div>
+						{:else}
+							<div class="text-muted-foreground space-y-2 text-sm">
+								<p>
+									Meditation weekly goal:
+									<strong class="text-foreground ml-1">
+										{data.dashboardGoals.meditationWeeklyGoal} session{data.dashboardGoals
+											.meditationWeeklyGoal === 1
+											? ''
+											: 's'}/week
+									</strong>
+								</p>
+								<p>
+									Workout pace thresholds:
+									<strong class="text-foreground ml-1">
+										{data.dashboardGoals.workoutGreenThreshold}+ green ·
+										{data.dashboardGoals.workoutAmberThreshold}-{data.dashboardGoals
+											.workoutGreenThreshold - 1} amber · below {data.dashboardGoals
+											.workoutAmberThreshold} red
 									</strong>
 								</p>
 							</div>


### PR DESCRIPTION
## Summary
- Closes #298. Follow-up to #282, which hardcoded the meditation weekly goal and workout pace thresholds shown on the dashboard.
- Adds a per-user `dashboard_goal_settings` table (`meditationWeeklyGoal`, `workoutGreenThreshold`, `workoutAmberThreshold`), following the existing `goalWeights`/`visitStatusSettings` pattern.
- Adds a "Dashboard Goals" settings section on the Profile page (next to the existing Visit Settings section) to edit these values, with validation that the amber threshold must be less than the green threshold.
- Wires the dashboard load function and the Meditation Sessions / Workout Breakdown widgets to read from these settings instead of the hardcoded constants.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — passes (pre-existing dead-code/dependency warnings only, unrelated to this change)
- [x] `npm run test` — 360/360 passing, including new tests for `normalizeDashboardGoals` and `updateDashboardGoalSettingsSchema`
- [x] `npm run build` — succeeds
- [x] Verified manually in the browser: edited Dashboard Goals on the Profile page, confirmed values persist and the Dashboard's meditation goal + workout pace labels update accordingly; confirmed invalid threshold combos (amber >= green) are rejected with a validation error; restored account to default values afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)