### PR TITLE
fix: prevent horizontal overflow across breakpoints

### DIFF
--- a/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -13,7 +13,7 @@
 <main
 	bind:this={ref}
 	data-slot="sidebar-inset"
-	class={cn("bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col", className)}
+	class={cn("bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full min-w-0 flex-1 flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}


### PR DESCRIPTION
## Summary
- Audited every route (splash, auth, dashboard, tasks, meditation, fitness, journal, visits, profile, admin) at 500px, 768px, 1024px, and 1440px viewport widths using the browser.
- Found and fixed a real bug: the shadcn sidebar's `<main>` element (`src/lib/components/ui/sidebar/sidebar-inset.svelte`) had `flex-1` but no `min-w-0`. Its automatic flex minimum size fell back to the min-content width of its descendants, so any page with an unbroken run of text deep in a `truncate`/flex chain (e.g. a long journal entry title surfaced in the dashboard's Recent Activity feed) forced the whole layout wider than the viewport — producing a page-level horizontal scrollbar at every breakpoint below ~900px. Adding `min-w-0` lets `main` shrink to fit the available width as intended, which is the standard fix for this well-known flexbox sizing pitfall.
- Re-verified every route at all four breakpoints after the fix: no horizontal overflow anywhere, sidebar collapse/mobile-drawer both work correctly.

## Note on pre-commit hook
The commit was pushed with `--no-verify` after confirming (and getting sign-off) that the `fmt` step in `lint-staged` fails for an unrelated, pre-existing reason: `oxfmt` 0.62.0 silently excludes the entire `src/lib/components/ui/` directory from formatting (reproduced repo-wide, not specific to this file). `oxlint` and `svelte-check` both pass cleanly on the changed file, and the fix is a single-line, correctly-formatted change.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` — clean (pre-existing unrelated dead-code/dependency warnings only)
- [x] `npm test` — 360/360 unit tests pass
- [x] Manually verified no horizontal overflow on all routes at 500px/768px/1024px/1440px via browser automation
- [x] Verified mobile sidebar drawer and desktop sidebar collapse both render correctly

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)