### PR TITLE
fix: mood tab broken on mobile

### DIFF
--- a/src/lib/components/mood/MoodByDayOfWeekChart.svelte
+++ b/src/lib/components/mood/MoodByDayOfWeekChart.svelte
@@ -28,7 +28,7 @@
 	const hasData = $derived(weekdayAvg.some((p) => p.count > 0));
 
 	const chartConfig = {
-		avgScore: { label: 'Avg mood', color: 'var(--color-orange)' }
+		avgScore: { label: 'Avg mood', color: 'oklch(var(--color-orange))' }
 	} satisfies Chart.ChartConfig;
 </script>
 

--- a/src/lib/components/mood/MoodDistributionChart.svelte
+++ b/src/lib/components/mood/MoodDistributionChart.svelte
@@ -64,7 +64,7 @@
 							cRange={distribution.map((item) => item.fill)}
 							innerRadius={0.62}
 							cornerRadius={6}
-							padAngle={2}
+							padAngle={0.02}
 						>
 							{#snippet tooltip()}
 								<Chart.Tooltip indicator="dot" />

--- a/src/lib/components/tasks/MoodTrackerView.svelte
+++ b/src/lib/components/tasks/MoodTrackerView.svelte
@@ -137,7 +137,7 @@
 	<!-- Charts grid -->
 	<div class="grid gap-5 md:grid-cols-2 md:items-start">
 		<!-- Left column: trend + heatmap -->
-		<div class="space-y-5">
+		<div class="min-w-0 space-y-5">
 			<MoodTrendChart
 				points={mood.trendPoints}
 				rollingAvgPoints={mood.rollingAvgPoints}
@@ -148,7 +148,7 @@
 		</div>
 
 		<!-- Right column: weekday bar + distribution -->
-		<div class="space-y-5">
+		<div class="min-w-0 space-y-5">
 			<MoodByDayOfWeekChart weekdayAvg={mood.weekdayAvg} rangeLabel={mood.rangeLabel} />
 			<MoodDistributionChart
 				distribution={mood.distribution}

--- a/src/lib/utils/mood.test.ts
+++ b/src/lib/utils/mood.test.ts
@@ -55,7 +55,7 @@ describe('getMoodScore', () => {
 describe('getMoodChartColor', () => {
 	it('returns the correct chart color for known moods', () => {
 		expect(getMoodChartColor('sad')).toBe('var(--chart-5)');
-		expect(getMoodChartColor('content')).toBe('var(--color-green)');
+		expect(getMoodChartColor('content')).toBe('oklch(var(--color-green))');
 	});
 
 	it('returns the fallback chart color for unknown moods', () => {

--- a/src/lib/utils/mood.ts
+++ b/src/lib/utils/mood.ts
@@ -45,7 +45,7 @@ export const moodOptions = [
 		value: 'content',
 		label: 'Content',
 		score: 7,
-		chartColor: 'var(--color-green)',
+		chartColor: 'oklch(var(--color-green))',
 		buttonClass: 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
 	},
 	{


### PR DESCRIPTION
## Summary
- `MoodDistributionChart.svelte` passed `padAngle={2}` (radians) to layerchart's `PieChart` — a value ~100x too large. With multiple slices, the padding consumed the entire circle, collapsing every arc to a degenerate zero-area line segment instead of a wedge, so the donut chart rendered completely blank.
- `mood.ts` and `MoodByDayOfWeekChart.svelte` used `var(--color-green)`/`var(--color-orange)` directly as raw chart colors. `app.css` defines these tokens twice (an invalid bare-channel value in the unlayered `:root` block, and a valid wrapped value in the `@theme inline` layer) — unlayered CSS wins, so the raw `var()` resolved to an invalid color. Wrapped both in `oklch(...)`, matching every other correct usage already in the codebase. This fixes the "Content" mood's missing legend dot/pie slice and the "Mood by day of week" bar chart's unfilled bars.
- `MoodTrackerView.svelte`'s two-column charts grid had no `min-w-0` on its column wrappers, so on the single mobile column a wide descendant could force a grid item past its track's available width, pushing the "Mood distribution" card wider than the viewport and clipping its legend rows.

## Test plan
- [x] `npm run check` (svelte-check) passes
- [x] `npm run test` (vitest, includes updated `mood.test.ts`) passes
- [x] Verified in Chrome at a mobile viewport (~500px, below the `md` breakpoint) with seeded mood log data: donut chart renders all slices including a colored "Content" slice, day-of-week bars render filled, legend rows fit within the card with no horizontal overflow
- [x] Verified at desktop viewport width: same fixes hold, no regressions

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)