### PR TITLE
Fix stale dialog-scaffold note and Copilot mirror content

### DIFF
--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -110,7 +110,7 @@ Do **not** use this agent for visual/UI-only feedback unless security-relevant.
 5. **Fix Guidance**
    - Provide concrete code-level remediation and safer alternatives.
 6. **Report Creation**
-   - Save a review report at: `docs/code-review/[YYYY-MM-DD]-review.md`.
+   - Save a review report at: `docs/security-review/[YYYY-MM-DD]-review.md`.
 
 ## Severity Model
 

--- a/.github/skills/shadcn-svelte-components/SKILL.md
+++ b/.github/skills/shadcn-svelte-components/SKILL.md
@@ -17,11 +17,11 @@ Use shadcn-svelte components (bits-ui) for UI. Import with namespace pattern.
 
 ```svelte
 <script lang="ts">
-	import * as Dialog from '$comp/ui/dialog';
-	import * as DropdownMenu from '$comp/ui/dropdown-menu';
-	import * as Tooltip from '$comp/ui/tooltip';
-	import { Button } from '$comp/ui/button';
-	import { Input } from '$comp/ui/input';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
 </script>
 ```
 
@@ -99,8 +99,8 @@ When using trigger components with custom elements like Button, **always use the
 
 ```svelte
 <script lang="ts">
-	import * as Dialog from '$comp/ui/dialog';
-	import { Button } from '$comp/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
 
 	let openCreateDialog = $state(false);
 </script>
@@ -143,7 +143,7 @@ When using trigger components with custom elements like Button, **always use the
 
 ```svelte
 <script lang="ts">
-	import * as DropdownMenu from '$comp/ui/dropdown-menu';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { statusOptions } from './options';
 </script>
 
@@ -167,7 +167,7 @@ When using trigger components with custom elements like Button, **always use the
 
 ```typescript
 // options.ts
-import type { DropdownItem } from '$shared/types';
+import type { DropdownItem } from '$lib/types';
 
 export enum Status {
     Active = 'active',

--- a/.github/skills/svelte5-best-practices/references/sveltekit.md
+++ b/.github/skills/svelte5-best-practices/references/sveltekit.md
@@ -381,7 +381,7 @@ export const load = async ({ locals }) => {
 **Pattern 3: Client-Only State**
 ```ts
 // stores.svelte.ts
-import { browser } from '$app/environment';
+import { browser } from '$app/env';
 
 function createClientStore() {
   if (!browser) return { value: null };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/
 
 ## Log-entry dialog pattern (`src/lib/components/fitness/dialogs/`)
 
-`LogWorkoutDialog`, `LogMealDialog`, `LogWeightDialog`, `CreateReminderDialog`, `SetCalorieTargetDialog`, `SetGoalWeightDialog` all follow one identical skeleton — **match it exactly** when adding a new one (a shared scaffold command for this doesn't exist yet):
+`LogWorkoutDialog`, `LogMealDialog`, `LogWeightDialog`, `CreateReminderDialog`, `SetCalorieTargetDialog`, `SetGoalWeightDialog` all follow one identical skeleton — **match it exactly** when adding a new one. The shared toolkit's `/scaffold-form` command's "dialog-based entry form" flavor targets this exact shape — point it at one of these dialogs as the exemplar rather than hand-rolling a new one from scratch:
 
 ```ts
 let {
@@ -147,6 +147,6 @@ npm run db:migrate      # drizzle-kit migrate
 
 ## Shared toolkit
 
-This repo uses the shared `sveltekit-toolkit` plugin (see `.claude/settings.json`) for skills (svelte5-best-practices, better-auth-best-practices, shadcn-svelte-components, tailwind-patterns, frontend-design, web-design-reviewer, svelte-code-writer) and two review agents.
+This repo uses the shared `sveltekit-toolkit` plugin (see `.claude/settings.json`) for skills (svelte5-best-practices, better-auth-best-practices, shadcn-svelte-components, tailwind-patterns, frontend-design, web-design-reviewer, svelte-code-writer), two review agents, a `/propagate` command for replicating a shared-dependency fix across the sibling repos (`meal-planner`, `sheppakai-budget`), and a `/scaffold-form` command for scaffolding a new form/CRUD/dialog feature — see the "Log-entry dialog pattern" above for this repo's dialog flavor.
 
 The `code-structure-reviewer` and `security-reviewer` agents (from the shared plugin) are available on demand — invoke them when you want a structural or security pass, not automatically on every PR. They aren't wired into any automated hook.


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s "Log-entry dialog pattern" section claimed "a shared scaffold command for this doesn't exist yet" — the toolkit's `/scaffold-form` command (dialog-based entry form flavor) was written to match this exact pattern and already existed. Updated the note and added `/scaffold-form`/`/propagate` to the "Shared toolkit" section.
- Fixed real drift in the `.github` Copilot mirror (most of the diff against the canonical toolkit skills was cosmetic markdown formatting and left alone; these two spots were genuine content bugs):
  - `shadcn-svelte-components/SKILL.md` still taught `$comp/ui/...` and `$shared/types` import aliases — fixed to `$lib/components/ui/...` / `$lib/types`.
  - `svelte5-best-practices/references/sveltekit.md`'s client-only-state example imported `browser` from `$app/environment`; this repo is on `$app/env` (per `CLAUDE.md`) — fixed to match.
- `security-reviewer.agent.md` told the agent to save its report to `docs/code-review/...` in one section and `docs/security-review/...` in another — unified on `docs/security-review/...`.

## Test plan
- Docs-only change; no app code touched. Ran through `lint-staged`/pre-commit and pre-push hooks on commit.