### PR TITLE
chore: silence fallow dev-dependencies-in-production false positives

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -13,13 +13,25 @@
 	"ignoreDependencies": [
 		"@flydotio/dockerfile",
 		"@internationalized/date",
+		"@lucide/svelte",
+		"@sveltejs/kit",
+		"@tailwindcss/typography",
 		"@tailwindcss/vite",
 		"@tanstack/table-core",
 		"bits-ui",
+		"clsx",
 		"dotenv",
 		"embla-carousel-svelte",
+		"layerchart",
+		"svelte",
+		"svelte-dnd-action",
+		"svelte-sonner",
+		"sveltekit-superforms",
+		"tailwind-merge",
 		"tailwind-variants",
-		"vaul-svelte"
+		"tailwindcss",
+		"vaul-svelte",
+		"zod"
 	],
 	"ignoreExports": [
 		{ "file": "src/lib/utils/ui.ts", "exports": ["WithoutChildrenOrChild", "WithElementRef"] }


### PR DESCRIPTION
## Summary
- `fallow dead-code` flags `@lucide/svelte`, `@sveltejs/kit`, `@tailwindcss/typography`, `clsx`, `layerchart`, `svelte`, `svelte-dnd-action`, `svelte-sonner`, `sveltekit-superforms`, `tailwind-merge`, `tailwindcss`, and `zod` as devDependencies used in production, recommending they move to `dependencies`.
- These are all imported by server-side code, but SvelteKit's adapter-node build (`vite build`) fully bundles them into `build/server/chunks/*.js` — they never need to be resolved from `node_modules` at runtime.
- Verified by building the app, running `npm prune --omit=dev` (matching this repo's Dockerfile), and booting `build/index.js` — it serves requests with zero `MODULE_NOT_FOUND` errors.
- Added the flagged packages to `.fallowrc.json`'s `ignoreDependencies` to silence the false-positive noise going forward.

## Test plan
- [x] `fallow dead-code --format human` no longer reports a "Dev dependencies used in production" section
- [x] `npm run build` succeeds
- [x] Full test suite passes (360 tests)
- [x] Pruned production build boots and serves requests (verified locally outside this PR's scope, in a scratch copy)