### PR TITLE
Add external API routes for tasks, mood, workouts, meals, and visits

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,8 @@ Authorization: Bearer <key>
   stored, so if you lose it you'll need to revoke it and create a new one.
 - Each key is scoped to a specific set of permissions (see below) and can optionally expire.
 - Each key has its own rate limit; repeated requests beyond it return `429`.
+- **Admin → API Logs** (`/admin`) shows the same audit trail described below — who made each
+  write, with which key, and what happened — for reviewing external activity in the UI.
 
 ## Scopes
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,197 @@
+# External API (`/api/v1`)
+
+A small JSON API for driving Synapse from outside the web UI — a personal AI assistant, a
+script, or a future mobile client. Authenticated with API keys, not session cookies, so an
+external tool never needs your personal login.
+
+## Authentication
+
+Every request must include:
+
+```
+Authorization: Bearer <key>
+```
+
+- The key is **only** ever read from the `Authorization` header. It is never accepted as a
+  query parameter, and a browser session cookie is never accepted as a fallback — the two
+  auth paths are fully independent.
+- Keys are created and revoked from **Admin → API Keys** (`/admin`) in the web UI, by an
+  admin account. The plaintext key is shown exactly once, at creation time — only a hash is
+  stored, so if you lose it you'll need to revoke it and create a new one.
+- Each key is scoped to a specific set of permissions (see below) and can optionally expire.
+- Each key has its own rate limit; repeated requests beyond it return `429`.
+
+## Scopes
+
+| Scope            | Grants                                                 |
+| ---------------- | ------------------------------------------------------ |
+| `tasks:read`     | `GET /api/v1/tasks`, `GET /api/v1/tasks/{id}`          |
+| `tasks:write`    | `POST /api/v1/tasks`, `PATCH /api/v1/tasks/{id}`       |
+| `mood:read`      | `GET /api/v1/mood`                                     |
+| `mood:write`     | `POST /api/v1/mood`                                    |
+| `workouts:read`  | `GET /api/v1/workouts`, `GET /api/v1/workouts/{id}`    |
+| `workouts:write` | `POST /api/v1/workouts`, `PATCH /api/v1/workouts/{id}` |
+| `meals:read`     | `GET /api/v1/meals`, `GET /api/v1/meals/{id}`          |
+| `meals:write`    | `POST /api/v1/meals`, `PATCH /api/v1/meals/{id}`       |
+| `visits:read`    | `GET /api/v1/visits`, `GET /api/v1/visits/{id}`        |
+| `visits:write`   | `POST /api/v1/visits`, `PATCH /api/v1/visits/{id}`     |
+| `people:read`    | `GET /api/v1/people`                                   |
+
+A key only needs the scopes for the endpoints it's meant to call — pick the narrowest set
+that covers the intended use. `people:read` exists mainly to resolve a `personId` for the
+visits endpoints — a visit is tied to an existing person record, not a free-text name.
+
+## Response shape
+
+Every response is one of exactly two shapes:
+
+```jsonc
+// Success
+{ "data": /* endpoint-specific payload */ }
+
+// Failure
+{ "error": { "code": "some_code", "message": "Human-readable explanation" } }
+```
+
+| HTTP status | `error.code`                                             | Meaning                                                                                                                                                                              |
+| ----------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 401         | `missing_header` / `invalid_scheme` / `malformed_header` | No `Authorization` header, wrong scheme, or malformed value                                                                                                                          |
+| 401         | `invalid_api_key`                                        | Key doesn't exist, is disabled, expired, or lacks the scope the endpoint requires (deliberately indistinguishable from an unknown key, so a caller can't probe which reason applies) |
+| 404         | `not_found`                                              | The record doesn't exist, or doesn't belong to this key's user                                                                                                                       |
+| 429         | `rate_limited`                                           | This key's rate limit or request quota was exceeded — wait and retry                                                                                                                 |
+| 400         | `validation_failed`                                      | Request body or query parameters failed validation                                                                                                                                   |
+| 400         | `invalid_json`                                           | Request body wasn't valid JSON                                                                                                                                                       |
+| 500         | `internal_error`                                         | Something went wrong server-side; check the server logs                                                                                                                              |
+
+Every write — successful or failed — is recorded in an internal audit log with the key that
+made it, so activity from an external tool is traceable if something looks wrong.
+
+## CORS
+
+No `Access-Control-Allow-Origin` header is ever returned. This API is for server-to-server
+or script use (curl, a backend job, an assistant's tool call) — not for calling directly
+from browser JavaScript on another site.
+
+## Endpoints
+
+### Tasks
+
+`GET /api/v1/tasks` — requires `tasks:read`. Query params (all optional): `state`
+(`new`/`in_progress`/`on_hold`/`blocked`/`done`), `priority` (1-4), `limit` (1-200, default 50).
+
+`GET /api/v1/tasks/{id}` — requires `tasks:read`.
+
+`POST /api/v1/tasks` — requires `tasks:write`. Body:
+
+```bash
+curl -X POST -H "Authorization: Bearer sk_live_xxx" -H "Content-Type: application/json" \
+  -d '{
+    "title": "Renew passport",
+    "description": "Expires next spring",
+    "tags": ["errands", "urgent"],
+    "dueDate": "2026-09-01",
+    "priority": 2,
+    "state": "new"
+  }' \
+  "https://synapse.example.com/api/v1/tasks"
+```
+
+`PATCH /api/v1/tasks/{id}` — requires `tasks:write`. Body is a partial update (any subset of
+the `POST` fields). Returns `200` with the updated task.
+
+### Mood
+
+`GET /api/v1/mood` — requires `mood:read`. Query params: `startDate`/`endDate`
+(`YYYY-MM-DD`, must be given together).
+
+`POST /api/v1/mood` — requires `mood:write`. There's at most one mood log per day, so this
+always creates-or-updates the entry for `date`:
+
+```bash
+curl -X POST -H "Authorization: Bearer sk_live_xxx" -H "Content-Type: application/json" \
+  -d '{ "date": "2026-08-25", "mood": "happy", "notes": "Slept well" }' \
+  "https://synapse.example.com/api/v1/mood"
+```
+
+### Workouts
+
+`GET /api/v1/workouts` — requires `workouts:read`. Query params: `startDate`/`endDate`,
+`type`, `limit` (1-200, default 50).
+
+`GET /api/v1/workouts/{id}` — requires `workouts:read`. Returns the workout with its
+`exercises` array.
+
+`POST /api/v1/workouts` — requires `workouts:write`. Body:
+
+```bash
+curl -X POST -H "Authorization: Bearer sk_live_xxx" -H "Content-Type: application/json" \
+  -d '{
+    "date": "2026-08-25",
+    "time": "07:30",
+    "type": "strength",
+    "durationMinutes": 45,
+    "exercises": [{ "exerciseName": "Squat", "sets": 3, "reps": 5, "weightLbs": 185 }]
+  }' \
+  "https://synapse.example.com/api/v1/workouts"
+```
+
+`PATCH /api/v1/workouts/{id}` — requires `workouts:write`. Passing `exercises` replaces the
+workout's full exercise list.
+
+### Meals
+
+`GET /api/v1/meals` — requires `meals:read`. Query params: `startDate`/`endDate`,
+`timeOfDay` (`breakfast`/`lunch`/`dinner`/`snack`), `limit` (1-200, default 50).
+
+`GET /api/v1/meals/{id}` — requires `meals:read`.
+
+`POST /api/v1/meals` — requires `meals:write`. Body:
+
+```bash
+curl -X POST -H "Authorization: Bearer sk_live_xxx" -H "Content-Type: application/json" \
+  -d '{ "date": "2026-08-25", "timeOfDay": "lunch", "description": "Chicken salad", "caloriesEstimate": 450 }' \
+  "https://synapse.example.com/api/v1/meals"
+```
+
+`PATCH /api/v1/meals/{id}` — requires `meals:write`.
+
+### People
+
+`GET /api/v1/people` — requires `people:read`. Query params: `includeArchived` (`true`/`false`,
+default `false`). Returns `{ id, name, isArchived, scheduledVisitDate }` for each person — use
+the `id` as `personId` when creating a visit.
+
+```bash
+curl -H "Authorization: Bearer sk_live_xxx" "https://synapse.example.com/api/v1/people"
+```
+
+### Visits
+
+`GET /api/v1/visits` — requires `visits:read`. Query params: `personId` (optional), `limit`
+(1-200, default 50).
+
+`GET /api/v1/visits/{id}` — requires `visits:read`.
+
+`POST /api/v1/visits` — requires `visits:write`. Body:
+
+```bash
+curl -X POST -H "Authorization: Bearer sk_live_xxx" -H "Content-Type: application/json" \
+  -d '{
+    "personId": "abc123",
+    "date": "2026-08-25",
+    "companions": ["Alex"],
+    "notes": "Coffee catch-up",
+    "followUpDate": "2026-09-25"
+  }' \
+  "https://synapse.example.com/api/v1/visits"
+```
+
+`PATCH /api/v1/visits/{id}` — requires `visits:write`.
+
+## Out of scope
+
+- OAuth2/third-party app authorization — API keys are enough for a single-user "give my own
+  tool a key" setup
+- Write access to user/auth-management endpoints
+- Webhooks
+- Delete endpoints — delete records from the web UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "synapse",
 			"version": "0.0.1",
 			"dependencies": {
+				"@better-auth/api-key": "^1.7.1",
 				"@sentry/sveltekit": "^10.71.0",
 				"better-auth": "^1.7.1",
 				"better-sqlite3": "^12.6.2",
@@ -396,6 +397,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@better-auth/api-key": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@better-auth/api-key/-/api-key-1.7.1.tgz",
+			"integrity": "sha512-lZr5RAiAE7RnPB4QCGK4GhcYJtG3xHtd2vw7DOBPscVTCBOs4vvxR93ACQFoCAAsDxMUbduwDkh92UYaI/MvgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"zod": "^4.3.6"
+			},
+			"peerDependencies": {
+				"@better-auth/core": "^1.7.1",
+				"@better-auth/utils": "0.4.2",
+				"better-auth": "^1.7.1",
+				"better-call": "1.4.0"
 			}
 		},
 		"node_modules/@better-auth/core": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"db:migrate": "drizzle-kit migrate"
 	},
 	"dependencies": {
+		"@better-auth/api-key": "^1.7.1",
 		"@sentry/sveltekit": "^10.71.0",
 		"better-auth": "^1.7.1",
 		"better-sqlite3": "^12.6.2",

--- a/src/lib/api-scopes.test.ts
+++ b/src/lib/api-scopes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { permissionsForScope, scopesToPermissions } from './api-scopes';
+
+describe('scopesToPermissions', () => {
+	it('groups flat scopes into a resource -> actions record', () => {
+		expect(scopesToPermissions(['tasks:read', 'tasks:write', 'mood:read'])).toEqual({
+			tasks: ['read', 'write'],
+			mood: ['read']
+		});
+	});
+
+	it('returns an empty record for no scopes', () => {
+		expect(scopesToPermissions([])).toEqual({});
+	});
+});
+
+describe('permissionsForScope', () => {
+	it('builds a single-scope permissions record', () => {
+		expect(permissionsForScope('visits:write')).toEqual({ visits: ['write'] });
+	});
+});

--- a/src/lib/api-scopes.ts
+++ b/src/lib/api-scopes.ts
@@ -1,0 +1,37 @@
+/**
+ * The full set of permissions an external API key can be granted. Kept as a flat
+ * `resource:action` string so it's easy to render as UI checkboxes and store on a
+ * superforms schema, while still mapping cleanly onto the `{ resource: string[] }`
+ * permissions record the better-auth API key plugin expects.
+ */
+export const API_SCOPES = [
+	'tasks:read',
+	'tasks:write',
+	'mood:read',
+	'mood:write',
+	'workouts:read',
+	'workouts:write',
+	'meals:read',
+	'meals:write',
+	'visits:read',
+	'visits:write',
+	'people:read'
+] as const;
+
+export type ApiScope = (typeof API_SCOPES)[number];
+
+/** Groups flat scope strings into the `{ resource: [action, ...] }` shape better-auth expects. */
+export function scopesToPermissions(scopes: readonly ApiScope[]): Record<string, string[]> {
+	const permissions: Record<string, string[]> = {};
+	for (const scope of scopes) {
+		const [resource, action] = scope.split(':');
+		(permissions[resource] ??= []).push(action);
+	}
+	return permissions;
+}
+
+/** Builds the single-scope permissions record passed to `auth.api.verifyApiKey`. */
+export function permissionsForScope(scope: ApiScope): Record<string, string[]> {
+	const [resource, action] = scope.split(':');
+	return { [resource]: [action] };
+}

--- a/src/lib/components/admin/AdminApiKeysTable.svelte
+++ b/src/lib/components/admin/AdminApiKeysTable.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { AdminApiKey } from './api-keys-columns';
+	import { columns } from './api-keys-columns';
+	import DataTable from './DataTable.svelte';
+
+	let { apiKeys }: { apiKeys: AdminApiKey[] } = $props();
+</script>
+
+<DataTable
+	{columns}
+	data={apiKeys}
+	defaultPageSize={10}
+	defaultSorting={[{ id: 'createdAt', desc: true }]}
+	emptyMessage="No API keys yet."
+/>

--- a/src/lib/components/admin/AdminApiLogsTable.svelte
+++ b/src/lib/components/admin/AdminApiLogsTable.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { AdminApiLogEntry } from './api-logs-columns';
+	import { columns } from './api-logs-columns';
+	import DataTable from './DataTable.svelte';
+
+	let { entries }: { entries: AdminApiLogEntry[] } = $props();
+</script>
+
+<DataTable
+	{columns}
+	data={entries}
+	defaultPageSize={10}
+	defaultSorting={[{ id: 'createdAt', desc: true }]}
+	emptyMessage="No API activity yet."
+/>

--- a/src/lib/components/admin/ApiKeyScopesBadges.svelte
+++ b/src/lib/components/admin/ApiKeyScopesBadges.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+
+	let { permissions }: { permissions: Record<string, string[]> | null } = $props();
+
+	const scopes = $derived(
+		permissions
+			? Object.entries(permissions).flatMap(([resource, actions]) =>
+					actions.map((action) => `${resource}:${action}`)
+				)
+			: []
+	);
+</script>
+
+{#if scopes.length > 0}
+	<div class="flex flex-wrap gap-1">
+		{#each scopes as scope (scope)}
+			<Badge variant="outline">{scope}</Badge>
+		{/each}
+	</div>
+{:else}
+	<span class="text-muted-foreground">—</span>
+{/if}

--- a/src/lib/components/admin/ApiKeyStatusBadge.svelte
+++ b/src/lib/components/admin/ApiKeyStatusBadge.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+
+	let { enabled }: { enabled: boolean } = $props();
+</script>
+
+{#if enabled}
+	<Badge
+		variant="outline"
+		class="border-green-200 bg-green-100 text-green-800 dark:border-green-500/30 dark:bg-green-900 dark:text-green-200"
+	>
+		Active
+	</Badge>
+{:else}
+	<Badge variant="destructive">Disabled</Badge>
+{/if}

--- a/src/lib/components/admin/api-key-table-actions.svelte
+++ b/src/lib/components/admin/api-key-table-actions.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import Trash2Icon from '@lucide/svelte/icons/trash-2';
+
+	import type { AdminApiKey } from './api-keys-columns';
+
+	let { apiKey }: { apiKey: AdminApiKey } = $props();
+
+	let openRevokeDialog = $state<boolean>(false);
+	let isSubmitting = $state<boolean>(false);
+</script>
+
+<Button
+	variant="ghost"
+	size="sm"
+	onclick={() => (openRevokeDialog = true)}
+	class="text-destructive hover:text-destructive flex items-center gap-2"
+>
+	<Trash2Icon class="size-4" />
+	Revoke
+</Button>
+
+<Dialog.Root bind:open={openRevokeDialog}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Revoke API key</Dialog.Title>
+			<Dialog.Description>
+				Are you sure you want to revoke "{apiKey.name || '(unnamed)'}"? Any tool using this key will
+				immediately lose access.
+			</Dialog.Description>
+		</Dialog.Header>
+		<form
+			method="POST"
+			action="?/revokeApiKey"
+			use:enhance={() => {
+				isSubmitting = true;
+
+				return async ({ update }) => {
+					await update();
+					isSubmitting = false;
+					openRevokeDialog = false;
+				};
+			}}
+		>
+			<input type="hidden" name="id" value={apiKey.id} />
+
+			<div class="flex justify-end gap-2 pt-4">
+				<Button type="button" variant="outline" onclick={() => (openRevokeDialog = false)}>
+					Cancel
+				</Button>
+				<Button type="submit" variant="destructive" disabled={isSubmitting}>
+					{isSubmitting ? 'Revoking...' : 'Revoke'}
+				</Button>
+			</div>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/admin/api-keys-columns.ts
+++ b/src/lib/components/admin/api-keys-columns.ts
@@ -1,0 +1,62 @@
+import { type Features, renderComponent } from '$lib/components/ui/data-table';
+import type { ColumnDef } from '@tanstack/table-core';
+
+import DataTableActions from './api-key-table-actions.svelte';
+import ApiKeyScopesBadges from './ApiKeyScopesBadges.svelte';
+import ApiKeyStatusBadge from './ApiKeyStatusBadge.svelte';
+
+export type AdminApiKey = {
+	id: string;
+	name: string | null;
+	start: string | null;
+	enabled: boolean;
+	permissions: Record<string, string[]> | null;
+	expiresAt: Date | string | null;
+	createdAt: Date | string;
+	lastRequest: Date | string | null;
+};
+
+export const columns: ColumnDef<Features, AdminApiKey>[] = [
+	{
+		accessorKey: 'name',
+		header: 'Name',
+		cell: ({ row }) => row.original.name || '(unnamed)'
+	},
+	{
+		accessorKey: 'start',
+		header: 'Key',
+		cell: ({ row }) => (row.original.start ? `${row.original.start}…` : '—')
+	},
+	{
+		id: 'scopes',
+		header: 'Scopes',
+		cell: ({ row }) =>
+			renderComponent(ApiKeyScopesBadges, { permissions: row.original.permissions })
+	},
+	{
+		accessorKey: 'enabled',
+		header: 'Status',
+		cell: ({ row }) => renderComponent(ApiKeyStatusBadge, { enabled: row.original.enabled })
+	},
+	{
+		accessorKey: 'expiresAt',
+		header: 'Expires',
+		cell: ({ row }) =>
+			row.original.expiresAt ? new Date(row.original.expiresAt).toLocaleDateString() : 'Never'
+	},
+	{
+		accessorKey: 'lastRequest',
+		header: 'Last used',
+		cell: ({ row }) =>
+			row.original.lastRequest ? new Date(row.original.lastRequest).toLocaleDateString() : 'Never'
+	},
+	{
+		accessorKey: 'createdAt',
+		header: 'Created',
+		cell: ({ row }) => new Date(row.original.createdAt).toLocaleDateString()
+	},
+	{
+		id: 'actions',
+		cell: ({ row }) => renderComponent(DataTableActions, { apiKey: row.original })
+	}
+];

--- a/src/lib/components/admin/api-logs-columns.ts
+++ b/src/lib/components/admin/api-logs-columns.ts
@@ -1,0 +1,89 @@
+import { type Features, renderComponent, renderSnippet } from '$lib/components/ui/data-table';
+import type { ColumnDef } from '@tanstack/table-core';
+import { createRawSnippet } from 'svelte';
+
+import DataTableSortButton from './DataTableSortButton.svelte';
+
+export type AdminApiLogEntry = {
+	id: string;
+	apiKeyId: string;
+	apiKeyName: string | null;
+	apiKeyExists: boolean;
+	userId: string;
+	user: { name: string | null; email: string };
+	method: string;
+	path: string;
+	action: string;
+	statusCode: number;
+	createdAt: string;
+};
+
+export const columns: ColumnDef<Features, AdminApiLogEntry>[] = [
+	{
+		accessorKey: 'createdAt',
+		header: ({ column }) =>
+			renderComponent(DataTableSortButton, {
+				columnName: 'Created',
+				onclick: column.getToggleSortingHandler()
+			}),
+		cell: ({ row }) => new Date(row.original.createdAt).toLocaleString()
+	},
+	{
+		accessorKey: 'user',
+		header: ({ column }) =>
+			renderComponent(DataTableSortButton, {
+				columnName: 'User',
+				onclick: column.getToggleSortingHandler()
+			}),
+		accessorFn: (row) => row.user.email,
+		cell: ({ row }) => row.original.user.name || row.original.user.email
+	},
+	{
+		accessorKey: 'apiKeyId',
+		header: 'API Key',
+		cell: ({ row }) => {
+			const keySnippet = createRawSnippet<[{ name: string | null; id: string; exists: boolean }]>(
+				(getKey) => {
+					const { name, id, exists } = getKey();
+					return {
+						render: () =>
+							exists
+								? `<span>${name || '(unnamed)'}</span>`
+								: `<div><span class="font-mono text-xs">${id}</span><div class="text-sm text-muted-foreground">Key no longer exists</div></div>`
+					};
+				}
+			);
+			return renderSnippet(keySnippet, {
+				name: row.original.apiKeyName,
+				id: row.original.apiKeyId,
+				exists: row.original.apiKeyExists
+			});
+		}
+	},
+	{
+		accessorKey: 'method',
+		header: 'Method'
+	},
+	{
+		accessorKey: 'path',
+		header: 'Path'
+	},
+	{
+		accessorKey: 'action',
+		header: 'Action'
+	},
+	{
+		accessorKey: 'statusCode',
+		header: 'Status',
+		cell: ({ row }) => {
+			const statusSnippet = createRawSnippet<[number]>((getStatus) => {
+				const status = getStatus();
+				const colorClass = status >= 400 ? 'text-red-600' : 'text-green-600';
+				return {
+					render: () => `<span class="font-medium ${colorClass}">${status}</span>`
+				};
+			});
+			return renderSnippet(statusSnippet, row.original.statusCode);
+		}
+	}
+];

--- a/src/lib/schemas/api-key.test.ts
+++ b/src/lib/schemas/api-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { createApiKeySchema, revokeApiKeySchema } from './api-key';
+
+describe('createApiKeySchema', () => {
+	it('accepts a valid key request', () => {
+		const result = createApiKeySchema.safeParse({ name: 'Assistant', scopes: ['tasks:read'] });
+		expect(result.success).toBe(true);
+	});
+
+	it('requires a name', () => {
+		expect(createApiKeySchema.safeParse({ name: '', scopes: ['tasks:read'] }).success).toBe(false);
+	});
+
+	it('requires at least one scope', () => {
+		expect(createApiKeySchema.safeParse({ name: 'Assistant', scopes: [] }).success).toBe(false);
+	});
+
+	it('rejects a scope outside API_SCOPES', () => {
+		expect(
+			createApiKeySchema.safeParse({ name: 'Assistant', scopes: ['transactions:read'] }).success
+		).toBe(false);
+	});
+
+	it('rejects expiresInDays outside 1-365', () => {
+		expect(
+			createApiKeySchema.safeParse({
+				name: 'Assistant',
+				scopes: ['tasks:read'],
+				expiresInDays: 400
+			}).success
+		).toBe(false);
+	});
+});
+
+describe('revokeApiKeySchema', () => {
+	it('requires a non-empty id', () => {
+		expect(revokeApiKeySchema.safeParse({ id: '' }).success).toBe(false);
+		expect(revokeApiKeySchema.safeParse({ id: 'key_abc' }).success).toBe(true);
+	});
+});

--- a/src/lib/schemas/api-key.ts
+++ b/src/lib/schemas/api-key.ts
@@ -1,0 +1,19 @@
+import { API_SCOPES } from '$lib/api-scopes';
+import { z } from 'zod';
+
+/**
+ * Schema for creating a new external API key from Admin → API Keys.
+ */
+export const createApiKeySchema = z.object({
+	name: z.string().min(1, 'Name is required').max(100, 'Name must be at most 100 characters'),
+	scopes: z.array(z.enum(API_SCOPES)).min(1, 'Select at least one scope'),
+	expiresInDays: z.coerce.number().int().min(1).max(365).optional()
+});
+
+/**
+ * Schema for revoking an API key. Better-auth key ids aren't UUIDs like this app's own
+ * table ids, so this is a plain non-empty string rather than `z.uuid()`.
+ */
+export const revokeApiKeySchema = z.object({
+	id: z.string().min(1, 'ID is required')
+});

--- a/src/lib/server/api/audit-log.test.ts
+++ b/src/lib/server/api/audit-log.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockValues = vi.hoisted(() =>
+	vi.fn<(entry: unknown) => Promise<void>>(async () => undefined)
+);
+const mockInsert = vi.hoisted(() =>
+	vi.fn<() => { values: typeof mockValues }>(() => ({ values: mockValues }))
+);
+const mockLoggerError = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>());
+
+vi.mock('$lib/server/db', () => ({ getDb: () => ({ insert: mockInsert }) }));
+vi.mock('$lib/server/db/schema', () => ({ apiAuditLog: {} }));
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		error: mockLoggerError,
+		warn: vi.fn<(...args: unknown[]) => void>(),
+		info: vi.fn<(...args: unknown[]) => void>()
+	}
+}));
+
+import { recordApiWrite } from './audit-log';
+
+const entry = {
+	apiKeyId: 'key-1',
+	userId: 'user-1',
+	method: 'POST',
+	path: '/api/v1/tasks',
+	action: 'tasks:write',
+	statusCode: 201
+};
+
+describe('recordApiWrite', () => {
+	beforeEach(() => {
+		mockInsert.mockClear();
+		mockValues.mockClear();
+		mockLoggerError.mockClear();
+	});
+
+	it('inserts the given entry', async () => {
+		await recordApiWrite(entry);
+		expect(mockValues).toHaveBeenCalledWith(entry);
+	});
+
+	it('logs and swallows a DB failure instead of throwing', async () => {
+		mockValues.mockRejectedValueOnce(new Error('db down'));
+
+		await expect(recordApiWrite(entry)).resolves.toBeUndefined();
+		expect(mockLoggerError).toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/api/audit-log.ts
+++ b/src/lib/server/api/audit-log.ts
@@ -1,0 +1,26 @@
+import { getDb } from '$lib/server/db';
+import { apiAuditLog } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logger';
+
+export type ApiAuditEntry = {
+	apiKeyId: string;
+	userId: string;
+	method: string;
+	path: string;
+	action: string;
+	statusCode: number;
+};
+
+/**
+ * Records which API key performed a write and what happened, for traceability of
+ * external/programmatic activity. Never lets a logging failure break the actual API
+ * response — an audit-log write failure is logged and swallowed rather than surfaced
+ * to the caller.
+ */
+export async function recordApiWrite(entry: ApiAuditEntry): Promise<void> {
+	try {
+		await getDb().insert(apiAuditLog).values(entry);
+	} catch (error) {
+		logger.error('Failed to write API audit log entry', error);
+	}
+}

--- a/src/lib/server/api/errors.test.ts
+++ b/src/lib/server/api/errors.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiWriteError } from './errors';
+
+describe('ApiWriteError', () => {
+	it('carries the code, message, and status', () => {
+		const error = new ApiWriteError('not_found', 'Task not found.', 404);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe('ApiWriteError');
+		expect(error.code).toBe('not_found');
+		expect(error.message).toBe('Task not found.');
+		expect(error.status).toBe(404);
+	});
+});

--- a/src/lib/server/api/errors.ts
+++ b/src/lib/server/api/errors.ts
@@ -1,0 +1,18 @@
+import type { ApiErrorCode } from './response';
+
+/**
+ * Thrown by `db/writes/*` functions for expected, user-facing failures (not found,
+ * a duplicate title, etc.) so route handlers can map them straight to an `apiError`
+ * response instead of falling through to a generic 500.
+ */
+export class ApiWriteError extends Error {
+	code: ApiErrorCode;
+	status: number;
+
+	constructor(code: ApiErrorCode, message: string, status: number) {
+		super(message);
+		this.name = 'ApiWriteError';
+		this.code = code;
+		this.status = status;
+	}
+}

--- a/src/lib/server/api/handle-write.test.ts
+++ b/src/lib/server/api/handle-write.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRecordApiWrite = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+const mockLoggerError = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>());
+
+vi.mock('./audit-log', () => ({ recordApiWrite: mockRecordApiWrite }));
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		error: mockLoggerError,
+		warn: vi.fn<(...args: unknown[]) => void>(),
+		info: vi.fn<(...args: unknown[]) => void>()
+	}
+}));
+
+import { ApiWriteError } from './errors';
+import { handleApiWrite } from './handle-write';
+
+const context = {
+	apiKeyId: 'key-1',
+	userId: 'user-1',
+	method: 'POST',
+	path: '/api/v1/tasks',
+	action: 'tasks:write'
+};
+
+describe('handleApiWrite', () => {
+	beforeEach(() => {
+		mockRecordApiWrite.mockClear();
+		mockLoggerError.mockClear();
+	});
+
+	it('returns the success envelope and records a success audit entry', async () => {
+		const response = await handleApiWrite(context, async () => ({ id: 'task-1' }), {
+			successStatus: 201,
+			failureMessage: 'Failed to create task'
+		});
+
+		expect(response.status).toBe(201);
+		expect(await response.json()).toEqual({ data: { id: 'task-1' } });
+		expect(mockRecordApiWrite).toHaveBeenCalledWith({ ...context, statusCode: 201 });
+	});
+
+	it('defaults to a 201 success status', async () => {
+		const response = await handleApiWrite(context, async () => ({ id: 'task-1' }), {
+			failureMessage: 'Failed to create task'
+		});
+
+		expect(response.status).toBe(201);
+	});
+
+	it('maps a thrown ApiWriteError to its typed error response and status', async () => {
+		const response = await handleApiWrite(
+			context,
+			async () => {
+				throw new ApiWriteError('not_found', 'Task not found.', 404);
+			},
+			{ failureMessage: 'Failed to update task' }
+		);
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({
+			error: { code: 'not_found', message: 'Task not found.' }
+		});
+		expect(mockRecordApiWrite).toHaveBeenCalledWith({ ...context, statusCode: 404 });
+		expect(mockLoggerError).not.toHaveBeenCalled();
+	});
+
+	it('maps an unexpected error to a logged 500', async () => {
+		const response = await handleApiWrite(
+			context,
+			async () => {
+				throw new Error('boom');
+			},
+			{ failureMessage: 'Failed to create task' }
+		);
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({
+			error: { code: 'internal_error', message: 'Failed to create task.' }
+		});
+		expect(mockRecordApiWrite).toHaveBeenCalledWith({ ...context, statusCode: 500 });
+		expect(mockLoggerError).toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/api/handle-write.ts
+++ b/src/lib/server/api/handle-write.ts
@@ -1,0 +1,43 @@
+import { logger } from '$lib/server/logger';
+
+import { recordApiWrite } from './audit-log';
+import { ApiWriteError } from './errors';
+import { apiError, apiSuccess } from './response';
+
+type WriteContext = {
+	apiKeyId: string;
+	userId: string;
+	method: string;
+	path: string;
+	action: string;
+};
+
+/**
+ * Shared success/failure envelope for every `/api/v1/*` write route: runs `perform`,
+ * records an audit-log entry for the outcome either way (per docs/API.md's audit-trail
+ * guarantee), and maps a thrown `ApiWriteError` to its typed response or anything else
+ * to a logged 500.
+ */
+export async function handleApiWrite<T>(
+	context: WriteContext,
+	perform: () => Promise<T>,
+	options: { successStatus?: number; failureMessage: string }
+): Promise<Response> {
+	const successStatus = options.successStatus ?? 201;
+
+	try {
+		const result = await perform();
+		await recordApiWrite({ ...context, statusCode: successStatus });
+		return apiSuccess(result, successStatus);
+	} catch (error) {
+		const statusCode = error instanceof ApiWriteError ? error.status : 500;
+		await recordApiWrite({ ...context, statusCode });
+
+		if (error instanceof ApiWriteError) {
+			return apiError(error.code, error.message, error.status);
+		}
+
+		logger.error(`API: ${options.failureMessage}`, error);
+		return apiError('internal_error', `${options.failureMessage}.`, 500);
+	}
+}

--- a/src/lib/server/api/require-api-key.test.ts
+++ b/src/lib/server/api/require-api-key.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockVerifyApiKey = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<unknown>>());
+const mockLoggerWarn = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>());
+
+vi.mock('../auth', () => ({
+	auth: { api: { verifyApiKey: mockVerifyApiKey } }
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		warn: mockLoggerWarn,
+		error: vi.fn<(...args: unknown[]) => void>(),
+		info: vi.fn<(...args: unknown[]) => void>(),
+		debug: vi.fn<(...args: unknown[]) => void>()
+	}
+}));
+
+import { requireApiKey } from './require-api-key';
+
+function request(headers: Record<string, string> = {}): Request {
+	return new Request('https://example.com/api/v1/tasks', { headers });
+}
+
+describe('requireApiKey', () => {
+	beforeEach(() => {
+		mockVerifyApiKey.mockReset();
+		mockLoggerWarn.mockReset();
+	});
+
+	it('rejects a missing Authorization header', async () => {
+		const result = await requireApiKey(request(), 'tasks:read');
+		expect(result).toEqual({
+			ok: false,
+			status: 401,
+			code: 'missing_header',
+			message: expect.any(String)
+		});
+		expect(mockVerifyApiKey).not.toHaveBeenCalled();
+		expect(mockLoggerWarn).toHaveBeenCalled();
+	});
+
+	it('rejects a malformed Authorization header', async () => {
+		const result = await requireApiKey(request({ authorization: 'Bearer' }), 'tasks:read');
+		expect(result).toEqual({
+			ok: false,
+			status: 401,
+			code: 'malformed_header',
+			message: expect.any(String)
+		});
+	});
+
+	it('passes the required scope as a permissions record to verifyApiKey', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: true,
+			error: null,
+			key: { id: 'key1', referenceId: 'user1' }
+		});
+
+		await requireApiKey(request({ authorization: 'Bearer sk_test_123' }), 'tasks:write');
+
+		expect(mockVerifyApiKey).toHaveBeenCalledWith({
+			body: { key: 'sk_test_123', permissions: { tasks: ['write'] } }
+		});
+	});
+
+	it('returns the api key id and user id on success', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: true,
+			error: null,
+			key: { id: 'key1', referenceId: 'user1' }
+		});
+
+		const result = await requireApiKey(
+			request({ authorization: 'Bearer sk_test_123' }),
+			'mood:read'
+		);
+
+		expect(result).toEqual({ ok: true, apiKeyId: 'key1', userId: 'user1' });
+	});
+
+	it('maps an invalid key (or insufficient scope) to a generic 401', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: false,
+			error: { message: 'not found', code: 'KEY_NOT_FOUND' },
+			key: null
+		});
+
+		const result = await requireApiKey(
+			request({ authorization: 'Bearer sk_test_123' }),
+			'tasks:write'
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			status: 401,
+			code: 'invalid_api_key',
+			message: expect.any(String)
+		});
+	});
+
+	it('maps a rate-limited key to 429', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: false,
+			error: { message: 'rate limited', code: 'RATE_LIMITED' },
+			key: null
+		});
+
+		const result = await requireApiKey(
+			request({ authorization: 'Bearer sk_test_123' }),
+			'tasks:read'
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			status: 429,
+			code: 'rate_limited',
+			message: expect.any(String)
+		});
+	});
+
+	it('maps a quota-exhausted key to 429', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: false,
+			error: { message: 'usage exceeded', code: 'USAGE_EXCEEDED' },
+			key: null
+		});
+
+		const result = await requireApiKey(
+			request({ authorization: 'Bearer sk_test_123' }),
+			'tasks:read'
+		);
+
+		expect(result.ok).toBe(false);
+		expect((result as { status: number }).status).toBe(429);
+	});
+
+	it('never logs the raw key value on failure', async () => {
+		mockVerifyApiKey.mockResolvedValue({
+			valid: false,
+			error: { message: 'invalid', code: 'INVALID_API_KEY' },
+			key: null
+		});
+
+		await requireApiKey(request({ authorization: 'Bearer sk_test_super_secret' }), 'tasks:read');
+
+		for (const call of mockLoggerWarn.mock.calls) {
+			expect(JSON.stringify(call)).not.toContain('sk_test_super_secret');
+		}
+	});
+});

--- a/src/lib/server/api/require-api-key.ts
+++ b/src/lib/server/api/require-api-key.ts
@@ -1,0 +1,66 @@
+import { permissionsForScope, type ApiScope } from '$lib/api-scopes';
+import { parseBearerToken } from '$lib/server/http/bearer-token';
+import { logger } from '$lib/server/logger';
+
+import { auth } from '../auth';
+import type { ApiErrorCode } from './response';
+
+type ApiKeyAuthSuccess = { ok: true; apiKeyId: string; userId: string };
+type ApiKeyAuthFailure = { ok: false; status: 401 | 429; code: ApiErrorCode; message: string };
+export type ApiKeyAuthResult = ApiKeyAuthSuccess | ApiKeyAuthFailure;
+
+// The api-key plugin folds a rate-limited verification and an out-of-quota key into
+// these two codes (see node_modules/@better-auth/api-key's verifyApiKey handler);
+// everything else (unknown key, disabled, expired, or a scope the key doesn't have)
+// comes back as a generic invalid-key failure, deliberately not distinguishable from
+// each other so a caller can't probe which reason applies to a given key.
+const RATE_LIMIT_ERROR_CODES = new Set(['RATE_LIMITED', 'USAGE_EXCEEDED']);
+
+/**
+ * Authenticates an external `/api/v1/*` request against an API key. Reads only the
+ * `Authorization: Bearer <key>` header — never a query string, never `event.locals` —
+ * so this is a fully separate auth path from session-cookie auth, by design: a valid
+ * session must never grant access to `/api/v1/*`, and a valid API key must never grant
+ * access to session-only routes.
+ */
+export async function requireApiKey(request: Request, scope: ApiScope): Promise<ApiKeyAuthResult> {
+	const path = new URL(request.url).pathname;
+	const parsed = parseBearerToken(request.headers.get('authorization'));
+
+	if (parsed.reason) {
+		logger.warn('API key auth failed', { path, reason: parsed.reason });
+		return {
+			ok: false,
+			status: 401,
+			code: parsed.reason,
+			message: 'Missing or malformed Authorization header. Use "Authorization: Bearer <key>".'
+		};
+	}
+
+	const result = await auth.api.verifyApiKey({
+		body: { key: parsed.token, permissions: permissionsForScope(scope) }
+	});
+
+	if (!result.valid || !result.key) {
+		const errorCode = result.error?.code;
+		logger.warn('API key auth failed', { path, reason: errorCode ?? 'invalid_api_key' });
+
+		if (errorCode !== undefined && RATE_LIMIT_ERROR_CODES.has(errorCode)) {
+			return {
+				ok: false,
+				status: 429,
+				code: 'rate_limited',
+				message: 'Rate limit exceeded for this API key. Try again later.'
+			};
+		}
+
+		return {
+			ok: false,
+			status: 401,
+			code: 'invalid_api_key',
+			message: 'Invalid API key.'
+		};
+	}
+
+	return { ok: true, apiKeyId: result.key.id, userId: result.key.referenceId };
+}

--- a/src/lib/server/api/response.test.ts
+++ b/src/lib/server/api/response.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiError, apiSuccess } from './response';
+
+describe('apiSuccess', () => {
+	it('wraps data in a { data } envelope with a 200 default status', async () => {
+		const response = apiSuccess({ id: '1' });
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ data: { id: '1' } });
+	});
+
+	it('honors a custom status', async () => {
+		const response = apiSuccess({ id: '1' }, 201);
+		expect(response.status).toBe(201);
+	});
+
+	it('never sets a CORS header', () => {
+		const response = apiSuccess({ id: '1' });
+		expect(response.headers.get('access-control-allow-origin')).toBeNull();
+	});
+});
+
+describe('apiError', () => {
+	it('wraps a code and message in an { error } envelope', async () => {
+		const response = apiError('invalid_api_key', 'Invalid API key.', 401);
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			error: { code: 'invalid_api_key', message: 'Invalid API key.' }
+		});
+	});
+
+	it('never sets a CORS header', () => {
+		const response = apiError('internal_error', 'Failed.', 500);
+		expect(response.headers.get('access-control-allow-origin')).toBeNull();
+	});
+});

--- a/src/lib/server/api/response.ts
+++ b/src/lib/server/api/response.ts
@@ -1,0 +1,24 @@
+import { json } from '@sveltejs/kit';
+
+/**
+ * JSON-API response envelope for `/api/v1/*` routes: exactly one success shape, one error
+ * shape, explicit HTTP status, no ad-hoc fourth shape.
+ */
+export type ApiErrorCode =
+	| 'missing_header'
+	| 'invalid_scheme'
+	| 'malformed_header'
+	| 'invalid_api_key'
+	| 'rate_limited'
+	| 'validation_failed'
+	| 'invalid_json'
+	| 'not_found'
+	| 'internal_error';
+
+export function apiSuccess<T>(data: T, status = 200): Response {
+	return json({ data }, { status });
+}
+
+export function apiError(code: ApiErrorCode, message: string, status: number): Response {
+	return json({ error: { code, message } }, { status });
+}

--- a/src/lib/server/api/schemas/meals.test.ts
+++ b/src/lib/server/api/schemas/meals.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiCreateMealSchema, apiMealListQuerySchema, apiUpdateMealSchema } from './meals';
+
+describe('apiCreateMealSchema', () => {
+	it('accepts a valid meal', () => {
+		const result = apiCreateMealSchema.safeParse({
+			date: '2026-08-25',
+			timeOfDay: 'lunch',
+			description: 'Chicken salad'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an empty description', () => {
+		expect(
+			apiCreateMealSchema.safeParse({ date: '2026-08-25', timeOfDay: 'lunch', description: '' })
+				.success
+		).toBe(false);
+	});
+
+	it('rejects an invalid timeOfDay', () => {
+		expect(
+			apiCreateMealSchema.safeParse({
+				date: '2026-08-25',
+				timeOfDay: 'brunch',
+				description: 'Eggs'
+			}).success
+		).toBe(false);
+	});
+});
+
+describe('apiUpdateMealSchema', () => {
+	it('accepts an empty partial update', () => {
+		expect(apiUpdateMealSchema.safeParse({}).success).toBe(true);
+	});
+});
+
+describe('apiMealListQuerySchema', () => {
+	it('defaults limit to 50', () => {
+		expect(apiMealListQuerySchema.safeParse({}).data?.limit).toBe(50);
+	});
+});

--- a/src/lib/server/api/schemas/meals.ts
+++ b/src/lib/server/api/schemas/meals.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)');
+
+const MealTypeEnum = z.enum(['breakfast', 'lunch', 'dinner', 'snack']);
+
+export const apiCreateMealSchema = z.object({
+	date: dateString,
+	timeOfDay: MealTypeEnum,
+	description: z.string().min(1, 'Description is required'),
+	caloriesEstimate: z.number().int().positive().optional()
+});
+
+export const apiUpdateMealSchema = z.object({
+	date: dateString.optional(),
+	timeOfDay: MealTypeEnum.optional(),
+	description: z.string().min(1, 'Description is required').optional(),
+	caloriesEstimate: z.number().int().positive().nullable().optional()
+});
+
+export const apiMealListQuerySchema = z.object({
+	startDate: dateString.optional(),
+	endDate: dateString.optional(),
+	timeOfDay: MealTypeEnum.optional(),
+	limit: z.coerce.number().int().min(1).max(200).default(50)
+});
+
+export type ApiCreateMealInput = z.infer<typeof apiCreateMealSchema>;
+export type ApiUpdateMealInput = z.infer<typeof apiUpdateMealSchema>;

--- a/src/lib/server/api/schemas/mood.test.ts
+++ b/src/lib/server/api/schemas/mood.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiMoodListQuerySchema, apiUpsertMoodSchema } from './mood';
+
+describe('apiUpsertMoodSchema', () => {
+	it('accepts a valid mood log', () => {
+		const result = apiUpsertMoodSchema.safeParse({ date: '2026-08-25', mood: 'happy' });
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an unrecognized mood value', () => {
+		expect(apiUpsertMoodSchema.safeParse({ date: '2026-08-25', mood: 'ecstatic' }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects mood "custom" without a customMood label', () => {
+		expect(apiUpsertMoodSchema.safeParse({ date: '2026-08-25', mood: 'custom' }).success).toBe(
+			false
+		);
+	});
+
+	it('accepts mood "custom" with a customMood label', () => {
+		const result = apiUpsertMoodSchema.safeParse({
+			date: '2026-08-25',
+			mood: 'custom',
+			customMood: 'Nostalgic'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a malformed date', () => {
+		expect(apiUpsertMoodSchema.safeParse({ date: '08-25-2026', mood: 'happy' }).success).toBe(
+			false
+		);
+	});
+});
+
+describe('apiMoodListQuerySchema', () => {
+	it('accepts no date range', () => {
+		expect(apiMoodListQuerySchema.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts a matched startDate/endDate pair', () => {
+		expect(
+			apiMoodListQuerySchema.safeParse({ startDate: '2026-08-01', endDate: '2026-08-31' }).success
+		).toBe(true);
+	});
+
+	it('rejects a startDate without an endDate', () => {
+		expect(apiMoodListQuerySchema.safeParse({ startDate: '2026-08-01' }).success).toBe(false);
+	});
+});

--- a/src/lib/server/api/schemas/mood.ts
+++ b/src/lib/server/api/schemas/mood.ts
@@ -1,0 +1,37 @@
+import { isMoodValue } from '$lib/utils/mood';
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)');
+
+export const apiUpsertMoodSchema = z
+	.object({
+		date: dateString,
+		mood: z.string().min(1, 'Choose a mood'),
+		customMood: z.string().trim().max(40, 'Custom mood must be 40 characters or fewer').optional(),
+		notes: z.string().trim().max(280, 'Notes must be 280 characters or fewer').optional()
+	})
+	.superRefine((data, ctx) => {
+		if (!isMoodValue(data.mood)) {
+			ctx.addIssue({ code: 'custom', message: 'Choose a valid mood', path: ['mood'] });
+		}
+
+		if (data.mood === 'custom' && !data.customMood?.trim()) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'Add a custom mood label',
+				path: ['customMood']
+			});
+		}
+	});
+
+export const apiMoodListQuerySchema = z
+	.object({
+		startDate: dateString.optional(),
+		endDate: dateString.optional()
+	})
+	.refine((data) => (data.startDate === undefined) === (data.endDate === undefined), {
+		message: 'startDate and endDate must be given together',
+		path: ['startDate']
+	});
+
+export type ApiUpsertMoodInput = z.infer<typeof apiUpsertMoodSchema>;

--- a/src/lib/server/api/schemas/people.test.ts
+++ b/src/lib/server/api/schemas/people.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiPeopleListQuerySchema } from './people';
+
+describe('apiPeopleListQuerySchema', () => {
+	it('defaults includeArchived to false when omitted', () => {
+		expect(apiPeopleListQuerySchema.safeParse({}).data?.includeArchived).toBe(false);
+	});
+
+	it('parses includeArchived=true', () => {
+		expect(
+			apiPeopleListQuerySchema.safeParse({ includeArchived: 'true' }).data?.includeArchived
+		).toBe(true);
+	});
+
+	it('rejects a non-boolean-ish value', () => {
+		expect(apiPeopleListQuerySchema.safeParse({ includeArchived: 'yes' }).success).toBe(false);
+	});
+});

--- a/src/lib/server/api/schemas/people.ts
+++ b/src/lib/server/api/schemas/people.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const apiPeopleListQuerySchema = z.object({
+	includeArchived: z
+		.enum(['true', 'false'])
+		.optional()
+		.transform((value) => value === 'true')
+});

--- a/src/lib/server/api/schemas/tasks.test.ts
+++ b/src/lib/server/api/schemas/tasks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiCreateTaskSchema, apiTaskListQuerySchema, apiUpdateTaskSchema } from './tasks';
+
+describe('apiCreateTaskSchema', () => {
+	it('accepts a minimal valid task', () => {
+		const result = apiCreateTaskSchema.safeParse({ title: 'Renew passport', priority: 2 });
+		expect(result.success).toBe(true);
+		expect(result.data?.state).toBe('new');
+	});
+
+	it('rejects an empty title', () => {
+		expect(apiCreateTaskSchema.safeParse({ title: '', priority: 1 }).success).toBe(false);
+	});
+
+	it('requires priority to be given', () => {
+		expect(apiCreateTaskSchema.safeParse({ title: 'x' }).success).toBe(false);
+	});
+
+	it('rejects a priority outside 1-4', () => {
+		expect(apiCreateTaskSchema.safeParse({ title: 'x', priority: 5 }).success).toBe(false);
+	});
+
+	it('rejects a malformed dueDate', () => {
+		expect(
+			apiCreateTaskSchema.safeParse({ title: 'x', priority: 1, dueDate: '08/25/2026' }).success
+		).toBe(false);
+	});
+
+	it('accepts tags as an array of strings', () => {
+		const result = apiCreateTaskSchema.safeParse({
+			title: 'x',
+			priority: 1,
+			tags: ['errands', 'urgent']
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('apiUpdateTaskSchema', () => {
+	it('accepts an empty partial update', () => {
+		expect(apiUpdateTaskSchema.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts null for nullable fields to clear them', () => {
+		const result = apiUpdateTaskSchema.safeParse({ description: null, tags: null, dueDate: null });
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('apiTaskListQuerySchema', () => {
+	it('defaults limit to 50', () => {
+		const result = apiTaskListQuerySchema.safeParse({});
+		expect(result.data?.limit).toBe(50);
+	});
+
+	it('coerces string query params to numbers', () => {
+		const result = apiTaskListQuerySchema.safeParse({ priority: '3', limit: '10' });
+		expect(result.data).toEqual({ priority: 3, limit: 10 });
+	});
+
+	it('rejects a limit above 200', () => {
+		expect(apiTaskListQuerySchema.safeParse({ limit: '500' }).success).toBe(false);
+	});
+
+	it('rejects an invalid state', () => {
+		expect(apiTaskListQuerySchema.safeParse({ state: 'archived' }).success).toBe(false);
+	});
+});

--- a/src/lib/server/api/schemas/tasks.ts
+++ b/src/lib/server/api/schemas/tasks.ts
@@ -1,0 +1,31 @@
+import { TaskStateEnum } from '$lib/schemas/task';
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)');
+
+export const apiCreateTaskSchema = z.object({
+	title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
+	description: z.string().max(5000, 'Description too long').optional(),
+	tags: z.array(z.string().min(1)).optional(),
+	dueDate: dateString.optional(),
+	priority: z.number().int().min(1, 'Priority must be between 1 and 4').max(4),
+	state: TaskStateEnum.default('new')
+});
+
+export const apiUpdateTaskSchema = z.object({
+	title: z.string().min(1, 'Title is required').max(200, 'Title too long').optional(),
+	description: z.string().max(5000, 'Description too long').nullable().optional(),
+	tags: z.array(z.string().min(1)).nullable().optional(),
+	dueDate: dateString.nullable().optional(),
+	priority: z.number().int().min(1, 'Priority must be between 1 and 4').max(4).optional(),
+	state: TaskStateEnum.optional()
+});
+
+export const apiTaskListQuerySchema = z.object({
+	state: TaskStateEnum.optional(),
+	priority: z.coerce.number().int().min(1).max(4).optional(),
+	limit: z.coerce.number().int().min(1).max(200).default(50)
+});
+
+export type ApiCreateTaskInput = z.infer<typeof apiCreateTaskSchema>;
+export type ApiUpdateTaskInput = z.infer<typeof apiUpdateTaskSchema>;

--- a/src/lib/server/api/schemas/visits.test.ts
+++ b/src/lib/server/api/schemas/visits.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiCreateVisitSchema, apiUpdateVisitSchema, apiVisitListQuerySchema } from './visits';
+
+describe('apiCreateVisitSchema', () => {
+	it('accepts a minimal valid visit', () => {
+		const result = apiCreateVisitSchema.safeParse({ personId: 'person-1', date: '2026-08-25' });
+		expect(result.success).toBe(true);
+	});
+
+	it('requires a personId', () => {
+		expect(apiCreateVisitSchema.safeParse({ date: '2026-08-25' }).success).toBe(false);
+	});
+
+	it('accepts companions as an array of strings', () => {
+		const result = apiCreateVisitSchema.safeParse({
+			personId: 'person-1',
+			date: '2026-08-25',
+			companions: ['Alex', 'Sam']
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('apiUpdateVisitSchema', () => {
+	it('accepts an empty partial update (no personId field at all)', () => {
+		expect(apiUpdateVisitSchema.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts nulling out optional fields', () => {
+		expect(
+			apiUpdateVisitSchema.safeParse({ time: null, companions: null, notes: null }).success
+		).toBe(true);
+	});
+});
+
+describe('apiVisitListQuerySchema', () => {
+	it('defaults limit to 50', () => {
+		expect(apiVisitListQuerySchema.safeParse({}).data?.limit).toBe(50);
+	});
+
+	it('accepts an optional personId filter', () => {
+		const result = apiVisitListQuerySchema.safeParse({ personId: 'person-1' });
+		expect(result.data?.personId).toBe('person-1');
+	});
+});

--- a/src/lib/server/api/schemas/visits.ts
+++ b/src/lib/server/api/schemas/visits.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)');
+const timeString = z.string().regex(/^\d{2}:\d{2}$/, 'Invalid time format (use HH:MM)');
+
+export const apiCreateVisitSchema = z.object({
+	personId: z.string().min(1, 'personId is required'),
+	date: dateString,
+	time: timeString.optional(),
+	companions: z.array(z.string().min(1)).optional(),
+	notes: z.string().optional(),
+	followUpDate: dateString.optional()
+});
+
+export const apiUpdateVisitSchema = z.object({
+	date: dateString.optional(),
+	time: timeString.nullable().optional(),
+	companions: z.array(z.string().min(1)).nullable().optional(),
+	notes: z.string().nullable().optional(),
+	followUpDate: dateString.nullable().optional()
+});
+
+export const apiVisitListQuerySchema = z.object({
+	personId: z.string().min(1).optional(),
+	limit: z.coerce.number().int().min(1).max(200).default(50)
+});
+
+export type ApiCreateVisitInput = z.infer<typeof apiCreateVisitSchema>;
+export type ApiUpdateVisitInput = z.infer<typeof apiUpdateVisitSchema>;

--- a/src/lib/server/api/schemas/workouts.test.ts
+++ b/src/lib/server/api/schemas/workouts.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	apiCreateWorkoutSchema,
+	apiUpdateWorkoutSchema,
+	apiWorkoutListQuerySchema
+} from './workouts';
+
+describe('apiCreateWorkoutSchema', () => {
+	it('accepts a minimal cardio workout', () => {
+		const result = apiCreateWorkoutSchema.safeParse({
+			date: '2026-08-25',
+			type: 'cardio',
+			durationMinutes: 30
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a strength workout with exercises', () => {
+		const result = apiCreateWorkoutSchema.safeParse({
+			date: '2026-08-25',
+			type: 'strength',
+			durationMinutes: 45,
+			exercises: [{ exerciseName: 'Squat', sets: 3, reps: 5, weightLbs: 185 }]
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an exercise with no name', () => {
+		const result = apiCreateWorkoutSchema.safeParse({
+			date: '2026-08-25',
+			type: 'strength',
+			exercises: [{ exerciseName: '' }]
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an invalid workout type', () => {
+		expect(apiCreateWorkoutSchema.safeParse({ date: '2026-08-25', type: 'yoga' }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects a malformed time', () => {
+		expect(
+			apiCreateWorkoutSchema.safeParse({ date: '2026-08-25', type: 'walk', time: '7:30am' }).success
+		).toBe(false);
+	});
+});
+
+describe('apiUpdateWorkoutSchema', () => {
+	it('accepts an empty partial update', () => {
+		expect(apiUpdateWorkoutSchema.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts nulling out optional fields', () => {
+		expect(apiUpdateWorkoutSchema.safeParse({ time: null, steps: null, notes: null }).success).toBe(
+			true
+		);
+	});
+});
+
+describe('apiWorkoutListQuerySchema', () => {
+	it('defaults limit to 50', () => {
+		expect(apiWorkoutListQuerySchema.safeParse({}).data?.limit).toBe(50);
+	});
+});

--- a/src/lib/server/api/schemas/workouts.ts
+++ b/src/lib/server/api/schemas/workouts.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD)');
+const timeString = z.string().regex(/^\d{2}:\d{2}$/, 'Invalid time format (use HH:MM)');
+
+const WorkoutTypeEnum = z.enum(['strength', 'cardio', 'hiit', 'walk', 'stretch', 'other']);
+
+const apiWorkoutExerciseSchema = z.object({
+	exerciseName: z.string().min(1, 'Exercise name is required'),
+	sets: z.number().int().positive().nullable().optional(),
+	reps: z.number().int().positive().nullable().optional(),
+	weightLbs: z.number().int().positive().nullable().optional()
+});
+
+export const apiCreateWorkoutSchema = z.object({
+	date: dateString,
+	time: timeString.optional(),
+	type: WorkoutTypeEnum,
+	durationMinutes: z.number().int().positive().optional(),
+	steps: z.number().int().positive().optional(),
+	notes: z.string().optional(),
+	exercises: z.array(apiWorkoutExerciseSchema).optional()
+});
+
+export const apiUpdateWorkoutSchema = z.object({
+	date: dateString.optional(),
+	time: timeString.nullable().optional(),
+	type: WorkoutTypeEnum.optional(),
+	durationMinutes: z.number().int().positive().nullable().optional(),
+	steps: z.number().int().positive().nullable().optional(),
+	notes: z.string().nullable().optional(),
+	exercises: z.array(apiWorkoutExerciseSchema).optional()
+});
+
+export const apiWorkoutListQuerySchema = z.object({
+	startDate: dateString.optional(),
+	endDate: dateString.optional(),
+	type: WorkoutTypeEnum.optional(),
+	limit: z.coerce.number().int().min(1).max(200).default(50)
+});
+
+export type ApiCreateWorkoutInput = z.infer<typeof apiCreateWorkoutSchema>;
+export type ApiUpdateWorkoutInput = z.infer<typeof apiUpdateWorkoutSchema>;

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -6,6 +6,7 @@ import {
 } from '$app/env/private';
 import { getRequestEvent } from '$app/server';
 import { logger } from '$lib/server/logger';
+import { apiKey } from '@better-auth/api-key';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { createAuthMiddleware } from 'better-auth/api';
@@ -27,7 +28,8 @@ export const auth = betterAuth({
 			user: schema.user,
 			session: schema.session,
 			account: schema.account,
-			verification: schema.verification
+			verification: schema.verification,
+			apikey: schema.apiKey
 		}
 	}),
 	emailAndPassword: {
@@ -167,5 +169,24 @@ export const auth = betterAuth({
 		max: 5, // max 5 requests per window per IP
 		storage: NODE_ENV === 'production' ? 'database' : 'memory'
 	},
-	plugins: [sveltekitCookies(getRequestEvent)] // make sure this is the last plugin in the array
+	plugins: [
+		apiKey({
+			references: 'user',
+			storage: 'database',
+			requireName: true,
+			// Only ever verified explicitly via auth.api.verifyApiKey (see src/lib/server/api/require-api-key.ts).
+			// Never let a valid API key stand in for a session on the app's own cookie-based routes.
+			enableSessionForAPIKeys: false,
+			keyExpiration: {
+				minExpiresIn: 1,
+				maxExpiresIn: 365
+			},
+			rateLimit: {
+				enabled: true,
+				timeWindow: 60 * 1000, // 1 minute
+				maxRequests: 100
+			}
+		}),
+		sveltekitCookies(getRequestEvent) // make sure this is the last plugin in the array
+	]
 });

--- a/src/lib/server/db/migrations/0024_warm_may_parker.sql
+++ b/src/lib/server/db/migrations/0024_warm_may_parker.sql
@@ -1,0 +1,39 @@
+CREATE TABLE `api_audit_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`api_key_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`method` text NOT NULL,
+	`path` text NOT NULL,
+	`action` text NOT NULL,
+	`status_code` integer NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `apikey` (
+	`id` text PRIMARY KEY NOT NULL,
+	`config_id` text DEFAULT 'default' NOT NULL,
+	`name` text,
+	`start` text,
+	`prefix` text,
+	`key` text NOT NULL,
+	`reference_id` text NOT NULL,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT true NOT NULL,
+	`rate_limit_enabled` integer DEFAULT true NOT NULL,
+	`rate_limit_time_window` integer,
+	`rate_limit_max` integer,
+	`request_count` integer DEFAULT 0 NOT NULL,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`permissions` text,
+	`metadata` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`reference_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `apikey_key_unique` ON `apikey` (`key`);

--- a/src/lib/server/db/migrations/meta/0024_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0024_snapshot.json
@@ -1,0 +1,2330 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "9d5406d8-6448-4184-8fc1-8d440d34b8a4",
+	"prevId": "ce9554b9-862e-49db-b5f6-3551a7bfdd46",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshTokenUpdatedAt": {
+					"name": "refreshTokenUpdatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"api_audit_log": {
+			"name": "api_audit_log",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"api_key_id": {
+					"name": "api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"method": {
+					"name": "method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status_code": {
+					"name": "status_code",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"api_audit_log_user_id_user_id_fk": {
+					"name": "api_audit_log_user_id_user_id_fk",
+					"tableFrom": "api_audit_log",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"apikey": {
+			"name": "apikey",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"config_id": {
+					"name": "config_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"apikey_key_unique": {
+					"name": "apikey_key_unique",
+					"columns": ["key"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"apikey_reference_id_user_id_fk": {
+					"name": "apikey_reference_id_user_id_fk",
+					"tableFrom": "apikey",
+					"tableTo": "user",
+					"columnsFrom": ["reference_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_entries": {
+			"name": "daily_agenda_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"completed": {
+					"name": "completed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_entries_user_date_idx": {
+					"name": "daily_agenda_entries_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_group_date_idx": {
+					"name": "daily_agenda_entries_group_date_idx",
+					"columns": ["template_group_id", "date"],
+					"isUnique": false
+				},
+				"daily_agenda_entries_default_unique_idx": {
+					"name": "daily_agenda_entries_default_unique_idx",
+					"columns": ["user_id", "template_group_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_entries_user_id_user_id_fk": {
+					"name": "daily_agenda_entries_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"daily_agenda_entries_template_id_daily_agenda_templates_id_fk": {
+					"name": "daily_agenda_entries_template_id_daily_agenda_templates_id_fk",
+					"tableFrom": "daily_agenda_entries",
+					"tableTo": "daily_agenda_templates",
+					"columnsFrom": ["template_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_agenda_templates": {
+			"name": "daily_agenda_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_group_id": {
+					"name": "template_group_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[0,1,2,3,4,5,6]'"
+				},
+				"starts_on": {
+					"name": "starts_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ends_on": {
+					"name": "ends_on",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_agenda_templates_user_range_idx": {
+					"name": "daily_agenda_templates_user_range_idx",
+					"columns": ["user_id", "starts_on", "ends_on"],
+					"isUnique": false
+				},
+				"daily_agenda_templates_group_idx": {
+					"name": "daily_agenda_templates_group_idx",
+					"columns": ["template_group_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"daily_agenda_templates_user_id_user_id_fk": {
+					"name": "daily_agenda_templates_user_id_user_id_fk",
+					"tableFrom": "daily_agenda_templates",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"daily_calorie_targets": {
+			"name": "daily_calorie_targets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_calories": {
+					"name": "target_calories",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"daily_calorie_targets_user_id_unique": {
+					"name": "daily_calorie_targets_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"daily_calorie_targets_user_id_user_id_fk": {
+					"name": "daily_calorie_targets_user_id_user_id_fk",
+					"tableFrom": "daily_calorie_targets",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"dashboard_goal_settings": {
+			"name": "dashboard_goal_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"meditation_weekly_goal": {
+					"name": "meditation_weekly_goal",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_green_threshold": {
+					"name": "workout_green_threshold",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_amber_threshold": {
+					"name": "workout_amber_threshold",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"dashboard_goal_settings_user_id_unique": {
+					"name": "dashboard_goal_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"dashboard_goal_settings_user_id_user_id_fk": {
+					"name": "dashboard_goal_settings_user_id_user_id_fk",
+					"tableFrom": "dashboard_goal_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"email_notifications": {
+			"name": "email_notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notification_type": {
+					"name": "notification_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_subject": {
+					"name": "email_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"email_notifications_userId_user_id_fk": {
+					"name": "email_notifications_userId_user_id_fk",
+					"tableFrom": "email_notifications",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"goal_weights": {
+			"name": "goal_weights",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_weight_lbs": {
+					"name": "target_weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"set_date": {
+					"name": "set_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"goal_weights_user_id_unique": {
+					"name": "goal_weights_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"goal_weights_user_id_user_id_fk": {
+					"name": "goal_weights_user_id_user_id_fk",
+					"tableFrom": "goal_weights",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"journal_entries": {
+			"name": "journal_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weather": {
+					"name": "weather",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"journal_entries_user_id_user_id_fk": {
+					"name": "journal_entries_user_id_user_id_fk",
+					"tableFrom": "journal_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meal_logs": {
+			"name": "meal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time_of_day": {
+					"name": "time_of_day",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"calories_estimate": {
+					"name": "calories_estimate",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meal_logs_user_id_user_id_fk": {
+					"name": "meal_logs_user_id_user_id_fk",
+					"tableFrom": "meal_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_routines": {
+			"name": "meditation_routines",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"link_url": {
+					"name": "link_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood_tags": {
+					"name": "mood_tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_predefined": {
+					"name": "is_predefined",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_routines_user_id_user_id_fk": {
+					"name": "meditation_routines_user_id_user_id_fk",
+					"tableFrom": "meditation_routines",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_schedules": {
+			"name": "meditation_schedules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_schedules_user_id_user_id_fk": {
+					"name": "meditation_schedules_user_id_user_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_schedules_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_schedules_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_schedules",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"meditation_sessions": {
+			"name": "meditation_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"routine_id": {
+					"name": "routine_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pre_mood_rating": {
+					"name": "pre_mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mood_rating": {
+					"name": "mood_rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"meditation_sessions_user_id_user_id_fk": {
+					"name": "meditation_sessions_user_id_user_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"meditation_sessions_routine_id_meditation_routines_id_fk": {
+					"name": "meditation_sessions_routine_id_meditation_routines_id_fk",
+					"tableFrom": "meditation_sessions",
+					"tableTo": "meditation_routines",
+					"columnsFrom": ["routine_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mood_logs": {
+			"name": "mood_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mood": {
+					"name": "mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"custom_mood": {
+					"name": "custom_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"mood_logs_user_date_idx": {
+					"name": "mood_logs_user_date_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": false
+				},
+				"mood_logs_user_date_unique_idx": {
+					"name": "mood_logs_user_date_unique_idx",
+					"columns": ["user_id", "date"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"mood_logs_user_id_user_id_fk": {
+					"name": "mood_logs_user_id_user_id_fk",
+					"tableFrom": "mood_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"people": {
+			"name": "people",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_exempt": {
+					"name": "is_exempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scheduled_visit_date": {
+					"name": "scheduled_visit_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"people_user_id_user_id_fk": {
+					"name": "people_user_id_user_id_fk",
+					"tableFrom": "people",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tasks": {
+			"name": "tasks",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"task_number": {
+					"name": "task_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_date": {
+					"name": "due_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'new'"
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tasks_task_number_unique": {
+					"name": "tasks_task_number_unique",
+					"columns": ["task_number"],
+					"isUnique": true
+				},
+				"tasks_user_state_sort_idx": {
+					"name": "tasks_user_state_sort_idx",
+					"columns": ["user_id", "state", "sort_order"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tasks_user_id_user_id_fk": {
+					"name": "tasks_user_id_user_id_fk",
+					"tableFrom": "tasks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visit_status_settings": {
+			"name": "visit_status_settings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"recent_to_overdue_days": {
+					"name": "recent_to_overdue_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"overdue_to_critical_days": {
+					"name": "overdue_to_critical_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"visit_status_settings_user_id_unique": {
+					"name": "visit_status_settings_user_id_unique",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"visit_status_settings_user_id_user_id_fk": {
+					"name": "visit_status_settings_user_id_user_id_fk",
+					"tableFrom": "visit_status_settings",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"visits": {
+			"name": "visits",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"person_id": {
+					"name": "person_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"companions": {
+					"name": "companions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"follow_up_date": {
+					"name": "follow_up_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"visits_person_id_people_id_fk": {
+					"name": "visits_person_id_people_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "people",
+					"columnsFrom": ["person_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"visits_user_id_user_id_fk": {
+					"name": "visits_user_id_user_id_fk",
+					"tableFrom": "visits",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"weight_entries": {
+			"name": "weight_entries",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"weight_entries_user_id_user_id_fk": {
+					"name": "weight_entries_user_id_user_id_fk",
+					"tableFrom": "weight_entries",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_exercises": {
+			"name": "workout_exercises",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_log_id": {
+					"name": "workout_log_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exercise_name": {
+					"name": "exercise_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sets": {
+					"name": "sets",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reps": {
+					"name": "reps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight_lbs": {
+					"name": "weight_lbs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_exercises_workout_log_id_workout_logs_id_fk": {
+					"name": "workout_exercises_workout_log_id_workout_logs_id_fk",
+					"tableFrom": "workout_exercises",
+					"tableTo": "workout_logs",
+					"columnsFrom": ["workout_log_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_logs": {
+			"name": "workout_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"steps": {
+					"name": "steps",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_logs_user_id_user_id_fk": {
+					"name": "workout_logs_user_id_user_id_fk",
+					"tableFrom": "workout_logs",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workout_reminders": {
+			"name": "workout_reminders",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workout_type": {
+					"name": "workout_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days_of_week": {
+					"name": "days_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"time": {
+					"name": "time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workout_reminders_user_id_user_id_fk": {
+					"name": "workout_reminders_user_id_user_id_fk",
+					"tableFrom": "workout_reminders",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
 			"when": 1785819982487,
 			"tag": "0023_spooky_jack_flag",
 			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "6",
+			"when": 1787694381737,
+			"tag": "0024_warm_may_parker",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -729,3 +729,80 @@ export const dashboardGoalSettingsRelations = relations(dashboardGoalSettings, (
 		references: [user.id]
 	})
 }));
+
+// ============================================================================
+// External API Tables
+// ============================================================================
+
+/**
+ * API Keys
+ * Mirrors the field set required by the `@better-auth/api-key` plugin's `apikey` model.
+ * Table name and every field name below must match the plugin's expectations exactly,
+ * since it queries this table by these names via the drizzle adapter's schema map in auth.ts.
+ */
+export const apiKey = sqliteTable('apikey', {
+	id: text('id').primaryKey().$defaultFn(generateId),
+	configId: text('config_id').notNull().default('default'),
+	name: text('name'),
+	start: text('start'),
+	prefix: text('prefix'),
+	key: text('key').notNull().unique(),
+	referenceId: text('reference_id')
+		.notNull()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	refillInterval: integer('refill_interval'),
+	refillAmount: integer('refill_amount'),
+	lastRefillAt: integer('last_refill_at', { mode: 'timestamp' }),
+	enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+	rateLimitEnabled: integer('rate_limit_enabled', { mode: 'boolean' }).notNull().default(true),
+	rateLimitTimeWindow: integer('rate_limit_time_window'),
+	rateLimitMax: integer('rate_limit_max'),
+	requestCount: integer('request_count').notNull().default(0),
+	remaining: integer('remaining'),
+	lastRequest: integer('last_request', { mode: 'timestamp' }),
+	expiresAt: integer('expires_at', { mode: 'timestamp' }),
+	permissions: text('permissions'),
+	metadata: text('metadata'),
+	createdAt: integer('created_at', { mode: 'timestamp' })
+		.notNull()
+		.$defaultFn(() => new Date()),
+	updatedAt: integer('updated_at', { mode: 'timestamp' })
+		.notNull()
+		.$defaultFn(() => new Date())
+});
+
+export const apiKeyRelations = relations(apiKey, ({ one }) => ({
+	user: one(user, {
+		fields: [apiKey.referenceId],
+		references: [user.id]
+	})
+}));
+
+/**
+ * API Audit Log
+ * Records which API key performed a write and what happened, for traceability of
+ * external/programmatic activity against the app's data.
+ */
+export const apiAuditLog = sqliteTable('api_audit_log', {
+	id: text('id').primaryKey().$defaultFn(generateId),
+	// Deliberately no FK to apiKey.id: the audit trail must survive a key being revoked
+	// (deleted), which is exactly the moment someone is most likely to want to review it.
+	apiKeyId: text('api_key_id').notNull(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	method: text('method').notNull(),
+	path: text('path').notNull(),
+	action: text('action').notNull(),
+	statusCode: integer('status_code').notNull(),
+	createdAt: text('created_at')
+		.notNull()
+		.$defaultFn(() => new Date().toISOString())
+});
+
+export const apiAuditLogRelations = relations(apiAuditLog, ({ one }) => ({
+	user: one(user, {
+		fields: [apiAuditLog.userId],
+		references: [user.id]
+	})
+}));

--- a/src/lib/server/db/writes/meals.ts
+++ b/src/lib/server/db/writes/meals.ts
@@ -1,0 +1,63 @@
+import { ApiWriteError } from '$lib/server/api/errors';
+import type { ApiCreateMealInput, ApiUpdateMealInput } from '$lib/server/api/schemas/meals';
+import { getDb } from '$lib/server/db';
+import { mealLogs } from '$lib/server/db/schema';
+import {
+	generateId,
+	withAuditFieldsForCreate,
+	withAuditFieldsForUpdate
+} from '$lib/server/db/utils';
+import { and, eq } from 'drizzle-orm';
+
+/**
+ * Insert path for API-key-driven meal logging. Mirrors the `logMeal` action in
+ * src/routes/(app)/fitness/+page.server.ts, kept as its own standalone function
+ * rather than sharing code with that UI action.
+ */
+export async function createMeal(userId: string, input: ApiCreateMealInput) {
+	const db = getDb();
+	const mealId = generateId();
+
+	await db.insert(mealLogs).values({
+		id: mealId,
+		userId,
+		date: input.date,
+		timeOfDay: input.timeOfDay,
+		description: input.description,
+		caloriesEstimate: input.caloriesEstimate ?? null,
+		...withAuditFieldsForCreate()
+	});
+
+	return db.query.mealLogs.findFirst({ where: eq(mealLogs.id, mealId) });
+}
+
+/**
+ * Update path for API-key-driven meal updates. Mirrors the `updateMeal` action in
+ * src/routes/(app)/fitness/+page.server.ts, kept as its own standalone function
+ * rather than sharing code with that UI action.
+ */
+export async function updateMeal(userId: string, mealId: string, input: ApiUpdateMealInput) {
+	const db = getDb();
+
+	const existing = await db.query.mealLogs.findFirst({
+		where: and(eq(mealLogs.id, mealId), eq(mealLogs.userId, userId))
+	});
+
+	if (!existing) {
+		throw new ApiWriteError('not_found', 'Meal not found.', 404);
+	}
+
+	await db
+		.update(mealLogs)
+		.set({
+			date: input.date ?? existing.date,
+			timeOfDay: input.timeOfDay ?? existing.timeOfDay,
+			description: input.description ?? existing.description,
+			caloriesEstimate:
+				input.caloriesEstimate !== undefined ? input.caloriesEstimate : existing.caloriesEstimate,
+			...withAuditFieldsForUpdate()
+		})
+		.where(and(eq(mealLogs.id, mealId), eq(mealLogs.userId, userId)));
+
+	return db.query.mealLogs.findFirst({ where: eq(mealLogs.id, mealId) });
+}

--- a/src/lib/server/db/writes/mood.ts
+++ b/src/lib/server/db/writes/mood.ts
@@ -1,0 +1,58 @@
+import type { ApiUpsertMoodInput } from '$lib/server/api/schemas/mood';
+import { getDb } from '$lib/server/db';
+import { moodLogs } from '$lib/server/db/schema';
+import {
+	generateId,
+	withAuditFieldsForCreate,
+	withAuditFieldsForUpdate
+} from '$lib/server/db/utils';
+import { and, eq } from 'drizzle-orm';
+
+function normalizeOptionalText(value: string | undefined): string | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Create-or-update path for API-key-driven mood logging. Mirrors the `upsertMood`
+ * action in src/routes/(app)/tasks/+page.server.ts — one mood log per user per day,
+ * kept as its own standalone function rather than sharing code with that UI action.
+ */
+export async function upsertMood(userId: string, input: ApiUpsertMoodInput) {
+	const db = getDb();
+
+	const existing = await db.query.moodLogs.findFirst({
+		where: and(eq(moodLogs.userId, userId), eq(moodLogs.date, input.date))
+	});
+
+	const customMood = input.mood === 'custom' ? normalizeOptionalText(input.customMood) : null;
+	const notes = normalizeOptionalText(input.notes);
+
+	if (existing) {
+		await db
+			.update(moodLogs)
+			.set({
+				mood: input.mood,
+				customMood,
+				notes,
+				...withAuditFieldsForUpdate()
+			})
+			.where(and(eq(moodLogs.id, existing.id), eq(moodLogs.userId, userId)));
+
+		return db.query.moodLogs.findFirst({ where: eq(moodLogs.id, existing.id) });
+	}
+
+	const moodLogId = generateId();
+	await db.insert(moodLogs).values({
+		id: moodLogId,
+		userId,
+		date: input.date,
+		mood: input.mood,
+		customMood,
+		notes,
+		...withAuditFieldsForCreate()
+	});
+
+	return db.query.moodLogs.findFirst({ where: eq(moodLogs.id, moodLogId) });
+}

--- a/src/lib/server/db/writes/tasks.ts
+++ b/src/lib/server/db/writes/tasks.ts
@@ -1,0 +1,204 @@
+import type { TaskState } from '$lib/schemas/task';
+import { ApiWriteError } from '$lib/server/api/errors';
+import type { ApiCreateTaskInput, ApiUpdateTaskInput } from '$lib/server/api/schemas/tasks';
+import { getDb } from '$lib/server/db';
+import { tasks } from '$lib/server/db/schema';
+import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
+import { and, eq, ne, sql } from 'drizzle-orm';
+
+const MAX_TASK_NUMBER_ATTEMPTS = 3;
+const TASK_NUMBER_CONSTRAINT_TEXT = 'UNIQUE constraint failed: tasks.task_number';
+
+function isTaskNumberConflict(error: unknown): boolean {
+	return error instanceof Error && error.message.includes(TASK_NUMBER_CONSTRAINT_TEXT);
+}
+
+function tagsToJson(tags: string[] | undefined | null): string | null {
+	if (!tags || tags.length === 0) return null;
+	return JSON.stringify(tags);
+}
+
+async function assertNoDuplicateTitle(userId: string, title: string, excludeTaskId?: string) {
+	const duplicate = await getDb().query.tasks.findFirst({
+		where: excludeTaskId
+			? and(eq(tasks.userId, userId), eq(tasks.title, title), ne(tasks.id, excludeTaskId))
+			: and(eq(tasks.userId, userId), eq(tasks.title, title))
+	});
+	if (duplicate) {
+		throw new ApiWriteError('validation_failed', 'A task with this name already exists.', 400);
+	}
+}
+
+/**
+ * Insert path for API-key-driven task creation. Mirrors the task-number-allocation
+ * transaction and duplicate-title check in
+ * src/routes/(app)/tasks/new/+page.server.ts, kept as its own standalone function
+ * rather than sharing code with that UI action.
+ */
+export async function createTask(userId: string, input: ApiCreateTaskInput) {
+	await assertNoDuplicateTitle(userId, input.title);
+
+	const db = getDb();
+
+	for (let attempt = 1; attempt <= MAX_TASK_NUMBER_ATTEMPTS; attempt += 1) {
+		try {
+			return db.transaction((tx) => {
+				const [taskNumberRow] = tx
+					.select({
+						nextTaskNumber: sql<number>`coalesce(max(${tasks.taskNumber}), 0) + 1`
+					})
+					.from(tasks)
+					.all();
+
+				const [sortOrderRow] = tx
+					.select({
+						maxSortOrder: sql<number>`coalesce(max(${tasks.sortOrder}), -1)`
+					})
+					.from(tasks)
+					.where(and(eq(tasks.userId, userId), eq(tasks.state, input.state)))
+					.all();
+
+				const timestamp = new Date().toISOString();
+				const nextTaskNumber = taskNumberRow?.nextTaskNumber ?? 1;
+				const nextSortOrder = (sortOrderRow?.maxSortOrder ?? -1) + 1;
+
+				const [newTask] = tx
+					.insert(tasks)
+					.values({
+						userId,
+						taskNumber: nextTaskNumber,
+						title: input.title,
+						description: input.description ?? null,
+						tags: tagsToJson(input.tags),
+						dueDate: input.dueDate ?? null,
+						priority: input.priority,
+						state: input.state,
+						sortOrder: nextSortOrder,
+						createdAt: timestamp,
+						updatedAt: timestamp
+					})
+					.returning()
+					.all();
+
+				return newTask;
+			});
+		} catch (error) {
+			if (isTaskNumberConflict(error) && attempt < MAX_TASK_NUMBER_ATTEMPTS) {
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	throw new Error('Failed to allocate a task number');
+}
+
+/**
+ * Update path for API-key-driven task updates. Mirrors the field-mapping and
+ * kanban-column resort-on-state-change logic in
+ * src/routes/(app)/tasks/[id]/edit/+page.server.ts, kept separate from that UI action.
+ */
+export async function updateTask(userId: string, taskId: string, input: ApiUpdateTaskInput) {
+	const db = getDb();
+
+	if (input.title) {
+		await assertNoDuplicateTitle(userId, input.title, taskId);
+	}
+
+	const existing = await db.query.tasks.findFirst({
+		where: and(eq(tasks.id, taskId), eq(tasks.userId, userId))
+	});
+
+	if (!existing) {
+		throw new ApiWriteError('not_found', 'Task not found.', 404);
+	}
+
+	const nextState = (input.state ?? existing.state) as TaskState;
+
+	const buildUpdateData = (existingState: string) => {
+		const updateData: Partial<typeof tasks.$inferInsert> = {
+			...withAuditFieldsForUpdate()
+		};
+
+		if (input.title !== undefined) updateData.title = input.title;
+		if (input.description !== undefined) updateData.description = input.description;
+		if (input.tags !== undefined) updateData.tags = tagsToJson(input.tags);
+		if (input.dueDate !== undefined) updateData.dueDate = input.dueDate;
+		if (input.priority !== undefined) updateData.priority = input.priority;
+
+		if (input.state !== undefined) {
+			updateData.state = input.state;
+			if (input.state === 'done' && existingState !== 'done') {
+				updateData.completedAt = new Date().toISOString();
+			} else if (input.state !== 'done' && existingState === 'done') {
+				updateData.completedAt = null;
+			}
+		}
+
+		return updateData;
+	};
+
+	if (nextState === existing.state) {
+		const updateData = buildUpdateData(existing.state);
+		await db
+			.update(tasks)
+			.set(updateData)
+			.where(and(eq(tasks.id, taskId), eq(tasks.userId, userId)));
+	} else {
+		const timestamp = new Date().toISOString();
+
+		// The better-sqlite3 driver runs transaction callbacks synchronously, so every
+		// query inside must use its sync execution method (`.all()`/`.run()`/`.sync()`)
+		// instead of `await` — an `async` callback throws "Transaction function cannot
+		// return a promise" at runtime.
+		db.transaction((tx) => {
+			const [targetSortOrderRow] = tx
+				.select({
+					maxSortOrder: sql<number>`coalesce(max(${tasks.sortOrder}), -1)`
+				})
+				.from(tasks)
+				.where(and(eq(tasks.userId, userId), eq(tasks.state, nextState)))
+				.all();
+
+			const sourceRows = tx.query.tasks
+				.findMany({
+					where: and(eq(tasks.userId, userId), eq(tasks.state, existing.state as TaskState)),
+					columns: { id: true },
+					orderBy: [tasks.sortOrder, tasks.taskNumber]
+				})
+				.sync();
+
+			const sourceTaskIds = sourceRows
+				.map((row) => row.id)
+				.filter((sourceTaskId) => sourceTaskId !== taskId);
+
+			const updateData = buildUpdateData(existing.state);
+
+			tx.update(tasks)
+				.set({
+					...updateData,
+					sortOrder: (targetSortOrderRow?.maxSortOrder ?? -1) + 1,
+					updatedAt: timestamp
+				})
+				.where(and(eq(tasks.id, taskId), eq(tasks.userId, userId)))
+				.run();
+
+			for (let index = 0; index < sourceTaskIds.length; index += 1) {
+				tx.update(tasks)
+					.set({ sortOrder: index, updatedAt: timestamp })
+					.where(and(eq(tasks.id, sourceTaskIds[index]), eq(tasks.userId, userId)))
+					.run();
+			}
+		});
+	}
+
+	const updated = await db.query.tasks.findFirst({
+		where: and(eq(tasks.id, taskId), eq(tasks.userId, userId))
+	});
+
+	if (!updated) {
+		throw new ApiWriteError('not_found', 'Task not found.', 404);
+	}
+
+	return updated;
+}

--- a/src/lib/server/db/writes/visits.ts
+++ b/src/lib/server/db/writes/visits.ts
@@ -1,0 +1,88 @@
+import { ApiWriteError } from '$lib/server/api/errors';
+import type { ApiCreateVisitInput, ApiUpdateVisitInput } from '$lib/server/api/schemas/visits';
+import { getDb } from '$lib/server/db';
+import { people, visits } from '$lib/server/db/schema';
+import {
+	generateId,
+	withAuditFieldsForCreate,
+	withAuditFieldsForUpdate
+} from '$lib/server/db/utils';
+import { and, eq } from 'drizzle-orm';
+
+function companionsToJson(companions: string[] | undefined | null): string | null {
+	if (!companions || companions.length === 0) return null;
+	return JSON.stringify(companions);
+}
+
+/**
+ * Insert path for API-key-driven visit logging. Mirrors the `logVisit` action in
+ * src/routes/(app)/visits/[id]/+page.server.ts — verifying the person belongs to the
+ * caller and clearing a stale `scheduledVisitDate` — kept as its own standalone
+ * function rather than sharing code with that UI action.
+ */
+export async function createVisit(userId: string, input: ApiCreateVisitInput) {
+	const db = getDb();
+
+	const person = await db.query.people.findFirst({
+		where: and(eq(people.id, input.personId), eq(people.userId, userId))
+	});
+
+	if (!person) {
+		throw new ApiWriteError('not_found', 'Person not found.', 404);
+	}
+
+	const visitId = generateId();
+
+	await db.insert(visits).values({
+		id: visitId,
+		personId: input.personId,
+		userId,
+		date: input.date,
+		time: input.time ?? null,
+		companions: companionsToJson(input.companions),
+		notes: input.notes ?? null,
+		followUpDate: input.followUpDate ?? null,
+		...withAuditFieldsForCreate()
+	});
+
+	if (person.scheduledVisitDate) {
+		await db
+			.update(people)
+			.set({ scheduledVisitDate: null, ...withAuditFieldsForUpdate() })
+			.where(and(eq(people.id, input.personId), eq(people.userId, userId)));
+	}
+
+	return db.query.visits.findFirst({ where: eq(visits.id, visitId) });
+}
+
+/**
+ * Update path for API-key-driven visit updates. Mirrors the `updateVisit` action in
+ * src/routes/(app)/visits/[id]/+page.server.ts, kept as its own standalone function
+ * rather than sharing code with that UI action.
+ */
+export async function updateVisit(userId: string, visitId: string, input: ApiUpdateVisitInput) {
+	const db = getDb();
+
+	const existing = await db.query.visits.findFirst({
+		where: and(eq(visits.id, visitId), eq(visits.userId, userId))
+	});
+
+	if (!existing) {
+		throw new ApiWriteError('not_found', 'Visit not found.', 404);
+	}
+
+	await db
+		.update(visits)
+		.set({
+			date: input.date ?? existing.date,
+			time: input.time !== undefined ? input.time : existing.time,
+			companions:
+				input.companions !== undefined ? companionsToJson(input.companions) : existing.companions,
+			notes: input.notes !== undefined ? input.notes : existing.notes,
+			followUpDate: input.followUpDate !== undefined ? input.followUpDate : existing.followUpDate,
+			...withAuditFieldsForUpdate()
+		})
+		.where(and(eq(visits.id, visitId), eq(visits.userId, userId)));
+
+	return db.query.visits.findFirst({ where: eq(visits.id, visitId) });
+}

--- a/src/lib/server/db/writes/workouts.ts
+++ b/src/lib/server/db/writes/workouts.ts
@@ -1,0 +1,137 @@
+import { ApiWriteError } from '$lib/server/api/errors';
+import type {
+	ApiCreateWorkoutInput,
+	ApiUpdateWorkoutInput
+} from '$lib/server/api/schemas/workouts';
+import { getDb } from '$lib/server/db';
+import { workoutExercises, workoutLogs } from '$lib/server/db/schema';
+import {
+	generateId,
+	withAuditFieldsForCreate,
+	withAuditFieldsForUpdate
+} from '$lib/server/db/utils';
+import { and, eq } from 'drizzle-orm';
+
+/**
+ * Insert path for API-key-driven workout logging, including strength-workout exercises.
+ * Mirrors the `logWorkout` action in src/routes/(app)/fitness/+page.server.ts, kept as
+ * its own standalone function rather than sharing code with that UI action.
+ */
+export async function createWorkout(userId: string, input: ApiCreateWorkoutInput) {
+	const db = getDb();
+	const workoutId = generateId();
+
+	await db.insert(workoutLogs).values({
+		id: workoutId,
+		userId,
+		date: input.date,
+		time: input.time ?? null,
+		type: input.type,
+		durationMinutes: input.durationMinutes ?? null,
+		steps: input.steps ?? null,
+		notes: input.notes ?? null,
+		...withAuditFieldsForCreate()
+	});
+
+	if (input.type === 'strength' && input.exercises && input.exercises.length > 0) {
+		await db.insert(workoutExercises).values(
+			input.exercises
+				.filter((exercise) => exercise.exerciseName.trim().length > 0)
+				.map((exercise) => ({
+					id: generateId(),
+					workoutLogId: workoutId,
+					exerciseName: exercise.exerciseName,
+					sets: exercise.sets ?? null,
+					reps: exercise.reps ?? null,
+					weightLbs: exercise.weightLbs ?? null,
+					...withAuditFieldsForCreate()
+				}))
+		);
+	}
+
+	return getWorkoutWithExercises(userId, workoutId);
+}
+
+/**
+ * Update path for API-key-driven workout updates. Mirrors the `updateWorkout` action
+ * in src/routes/(app)/fitness/+page.server.ts (replace-all-exercises-on-update),
+ * kept as its own standalone function rather than sharing code with that UI action.
+ */
+export async function updateWorkout(
+	userId: string,
+	workoutId: string,
+	input: ApiUpdateWorkoutInput
+) {
+	const db = getDb();
+
+	const existing = await db.query.workoutLogs.findFirst({
+		where: and(eq(workoutLogs.id, workoutId), eq(workoutLogs.userId, userId))
+	});
+
+	if (!existing) {
+		throw new ApiWriteError('not_found', 'Workout not found.', 404);
+	}
+
+	const nextType = input.type ?? existing.type;
+
+	// The better-sqlite3 driver runs transaction callbacks synchronously, so every query
+	// inside must use its sync execution method (`.run()`) instead of `await` — an
+	// `async` callback throws "Transaction function cannot return a promise" at runtime.
+	db.transaction((tx) => {
+		tx.update(workoutLogs)
+			.set({
+				date: input.date ?? existing.date,
+				time: input.time !== undefined ? input.time : existing.time,
+				type: nextType,
+				durationMinutes:
+					input.durationMinutes !== undefined ? input.durationMinutes : existing.durationMinutes,
+				steps: input.steps !== undefined ? input.steps : existing.steps,
+				notes: input.notes !== undefined ? input.notes : existing.notes,
+				...withAuditFieldsForUpdate()
+			})
+			.where(and(eq(workoutLogs.id, workoutId), eq(workoutLogs.userId, userId)))
+			.run();
+
+		if (input.exercises !== undefined) {
+			tx.delete(workoutExercises).where(eq(workoutExercises.workoutLogId, workoutId)).run();
+
+			if (nextType === 'strength' && input.exercises.length > 0) {
+				tx.insert(workoutExercises)
+					.values(
+						input.exercises
+							.filter((exercise) => exercise.exerciseName.trim().length > 0)
+							.map((exercise) => ({
+								id: generateId(),
+								workoutLogId: workoutId,
+								exerciseName: exercise.exerciseName,
+								sets: exercise.sets ?? null,
+								reps: exercise.reps ?? null,
+								weightLbs: exercise.weightLbs ?? null,
+								...withAuditFieldsForCreate()
+							}))
+					)
+					.run();
+			}
+		}
+	});
+
+	return getWorkoutWithExercises(userId, workoutId);
+}
+
+export async function getWorkoutWithExercises(userId: string, workoutId: string) {
+	const db = getDb();
+
+	const workout = await db.query.workoutLogs.findFirst({
+		where: and(eq(workoutLogs.id, workoutId), eq(workoutLogs.userId, userId))
+	});
+
+	if (!workout) {
+		throw new ApiWriteError('not_found', 'Workout not found.', 404);
+	}
+
+	const exercises = await db.query.workoutExercises.findMany({
+		where: eq(workoutExercises.workoutLogId, workoutId)
+	});
+
+	return { ...workout, exercises };
+}

--- a/src/lib/server/http/bearer-token.test.ts
+++ b/src/lib/server/http/bearer-token.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBearerToken } from './bearer-token';
+
+describe('parseBearerToken', () => {
+	it('rejects a missing header', () => {
+		expect(parseBearerToken(null)).toEqual({ reason: 'missing_header' });
+	});
+
+	it('rejects a non-bearer scheme', () => {
+		expect(parseBearerToken('Basic abc123')).toEqual({ reason: 'invalid_scheme' });
+	});
+
+	it('rejects a malformed header', () => {
+		expect(parseBearerToken('Bearer')).toEqual({ reason: 'malformed_header' });
+		expect(parseBearerToken('Bearer token extra')).toEqual({ reason: 'malformed_header' });
+		expect(parseBearerToken('Bearer ')).toEqual({ reason: 'malformed_header' });
+	});
+
+	it('extracts the token from a well-formed header', () => {
+		expect(parseBearerToken('Bearer sk_live_abc123')).toEqual({ token: 'sk_live_abc123' });
+	});
+});

--- a/src/lib/server/http/bearer-token.ts
+++ b/src/lib/server/http/bearer-token.ts
@@ -1,0 +1,32 @@
+export type BearerTokenFailureReason = 'missing_header' | 'invalid_scheme' | 'malformed_header';
+
+export type BearerTokenResult =
+	| { token: string; reason?: undefined }
+	| { token?: undefined; reason: BearerTokenFailureReason };
+
+/**
+ * Parses an `Authorization: Bearer <token>` header. Only ever reads the header string passed
+ * in — never a query string or any other request field — so callers that rely on this to keep
+ * secrets out of URLs/logs can't accidentally widen that guarantee.
+ */
+export function parseBearerToken(header: string | null): BearerTokenResult {
+	if (header === null) {
+		return { reason: 'missing_header' };
+	}
+
+	const parts = header.split(' ');
+	if (parts.length !== 2) {
+		return { reason: 'malformed_header' };
+	}
+
+	if (parts[0] !== 'Bearer') {
+		return { reason: 'invalid_scheme' };
+	}
+
+	const token = parts[1];
+	if (token.length === 0) {
+		return { reason: 'malformed_header' };
+	}
+
+	return { token };
+}

--- a/src/routes/(app)/admin/+page.server.ts
+++ b/src/routes/(app)/admin/+page.server.ts
@@ -1,23 +1,31 @@
+import { scopesToPermissions, type ApiScope } from '$lib/api-scopes';
+import { createApiKeySchema, revokeApiKeySchema } from '$lib/schemas/api-key';
 import { requireAdmin } from '$lib/server/actions/auth-guard';
+import { auth } from '$lib/server/auth';
 import { getDb } from '$lib/server/db';
 import { people, user, visits } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import { fail } from '@sveltejs/kit';
 import { asc, desc, eq, inArray } from 'drizzle-orm';
+import { message, superValidate } from 'sveltekit-superforms';
+import { zod4 } from 'sveltekit-superforms/adapters';
 
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ request }) => {
+	const createApiKeyForm = await superValidate(zod4(createApiKeySchema), { id: 'createApiKey' });
+
 	try {
 		const db = getDb();
 
-		const [users, archivedPeople] = await Promise.all([
+		const [users, archivedPeople, { apiKeys }] = await Promise.all([
 			db.query.user.findMany({ orderBy: [desc(user.createdAt)] }),
 			db.query.people.findMany({
 				where: eq(people.isArchived, true),
 				orderBy: [desc(people.updatedAt)]
-			})
+			}),
+			auth.api.listApiKeys({ headers: request.headers })
 		]);
 
 		const ownerIds = [...new Set(archivedPeople.map((person) => person.userId))];
@@ -51,11 +59,13 @@ export const load: PageServerLoad = async () => {
 				...person,
 				ownerEmail: ownerEmailById.get(person.userId) ?? 'Unknown',
 				lastVisitDate: latestVisitsByPersonId.get(person.id)?.date ?? null
-			}))
+			})),
+			apiKeys,
+			createApiKeyForm
 		};
 	} catch (err) {
 		logger.error('Failed to load admin dashboard data', err);
-		return { users: [], archivedPeople: [] };
+		return { users: [], archivedPeople: [], apiKeys: [], createApiKeyForm };
 	}
 };
 
@@ -80,6 +90,63 @@ export const actions = {
 		} catch (err) {
 			logger.error('Failed to unarchive person', err);
 			return fail(500, { error: 'Failed to unarchive person' });
+		}
+	}),
+
+	createApiKey: requireAdmin(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(createApiKeySchema));
+
+		if (!form.valid) {
+			return fail(400, { form });
+		}
+
+		try {
+			// Deliberately not passing `headers` here: the plugin only accepts server-only
+			// fields like `permissions` and rate-limit overrides on a "trusted server" call
+			// (no headers/request on the context), and rejects them outright on a
+			// session-based "client" call.
+			const created = await auth.api.createApiKey({
+				body: {
+					name: form.data.name,
+					userId: user.id,
+					permissions: scopesToPermissions(form.data.scopes as ApiScope[]),
+					expiresIn: form.data.expiresInDays ? form.data.expiresInDays * 86400 : undefined
+				}
+			});
+
+			logger.info('API key created', { keyId: created.id, scopes: form.data.scopes });
+
+			// The plaintext key is only ever returned here, once. Ride it alongside the
+			// usual message-bearing form rather than inventing a new response shape.
+			form.message = {
+				type: 'success',
+				text: 'API key created. Copy it now — it will not be shown again.'
+			};
+			return { form, apiKey: created.key };
+		} catch (err) {
+			logger.error('Failed to create API key', err);
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to create API key. Please try again.' },
+				{ status: 500 }
+			);
+		}
+	}),
+
+	revokeApiKey: requireAdmin(async ({ request }) => {
+		const formData = await request.formData();
+		const parsed = revokeApiKeySchema.safeParse({ id: formData.get('id') });
+
+		if (!parsed.success) {
+			return fail(400, { error: 'API key ID is required' });
+		}
+
+		try {
+			await auth.api.deleteApiKey({ body: { keyId: parsed.data.id }, headers: request.headers });
+			logger.info('API key revoked', { keyId: parsed.data.id });
+		} catch (err) {
+			logger.error('Failed to revoke API key', err);
+			return fail(500, { error: 'Failed to revoke API key' });
 		}
 	})
 } satisfies Actions;

--- a/src/routes/(app)/admin/+page.server.ts
+++ b/src/routes/(app)/admin/+page.server.ts
@@ -1,9 +1,10 @@
 import { scopesToPermissions, type ApiScope } from '$lib/api-scopes';
+import type { AdminApiLogEntry } from '$lib/components/admin/api-logs-columns';
 import { createApiKeySchema, revokeApiKeySchema } from '$lib/schemas/api-key';
 import { requireAdmin } from '$lib/server/actions/auth-guard';
 import { auth } from '$lib/server/auth';
 import { getDb } from '$lib/server/db';
-import { people, user, visits } from '$lib/server/db/schema';
+import { apiAuditLog, apiKey, people, user, visits } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import { fail } from '@sveltejs/kit';
@@ -19,14 +20,36 @@ export const load: PageServerLoad = async ({ request }) => {
 	try {
 		const db = getDb();
 
-		const [users, archivedPeople, { apiKeys }] = await Promise.all([
+		const [users, archivedPeople, { apiKeys }, auditEntries] = await Promise.all([
 			db.query.user.findMany({ orderBy: [desc(user.createdAt)] }),
 			db.query.people.findMany({
 				where: eq(people.isArchived, true),
 				orderBy: [desc(people.updatedAt)]
 			}),
-			auth.api.listApiKeys({ headers: request.headers })
+			auth.api.listApiKeys({ headers: request.headers }),
+			db.query.apiAuditLog.findMany({
+				with: { user: true },
+				orderBy: [desc(apiAuditLog.createdAt)]
+			})
 		]);
+
+		// apiKeyId has no FK to apiKey.id (by design, so the trail survives key revocation),
+		// so resolve names via a separate lookup rather than a join, tolerating ids with no match.
+		const apiKeyIds = [...new Set(auditEntries.map((entry) => entry.apiKeyId))];
+		const apiKeyRows =
+			apiKeyIds.length > 0
+				? await db
+						.select({ id: apiKey.id, name: apiKey.name })
+						.from(apiKey)
+						.where(inArray(apiKey.id, apiKeyIds))
+				: [];
+		const apiKeyNamesById = new Map(apiKeyRows.map((row) => [row.id, row.name]));
+
+		const apiLogs: AdminApiLogEntry[] = auditEntries.map((entry) => ({
+			...entry,
+			apiKeyName: apiKeyNamesById.get(entry.apiKeyId) ?? null,
+			apiKeyExists: apiKeyNamesById.has(entry.apiKeyId)
+		}));
 
 		const ownerIds = [...new Set(archivedPeople.map((person) => person.userId))];
 		const owners =
@@ -61,11 +84,12 @@ export const load: PageServerLoad = async ({ request }) => {
 				lastVisitDate: latestVisitsByPersonId.get(person.id)?.date ?? null
 			})),
 			apiKeys,
+			apiLogs,
 			createApiKeyForm
 		};
 	} catch (err) {
 		logger.error('Failed to load admin dashboard data', err);
-		return { users: [], archivedPeople: [], apiKeys: [], createApiKeyForm };
+		return { users: [], archivedPeople: [], apiKeys: [], apiLogs: [], createApiKeyForm };
 	}
 };
 

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -1,18 +1,29 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
+	import { API_SCOPES, type ApiScope } from '$lib/api-scopes';
+	import AdminApiKeysTable from '$lib/components/admin/AdminApiKeysTable.svelte';
 	import AdminArchivedPersonsTable from '$lib/components/admin/AdminArchivedPersonsTable.svelte';
 	import AdminUsersTable from '$lib/components/admin/AdminUsersTable.svelte';
 	import PageShell from '$lib/components/app/PageShell.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Checkbox } from '$lib/components/ui/checkbox';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
 	import * as Tabs from '$lib/components/ui/tabs';
+	import CopyIcon from '@lucide/svelte/icons/copy';
+	import { toast } from 'svelte-sonner';
+	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 
-	const activeTab = $derived.by(() =>
-		page.url.searchParams.get('tab') === 'archived-persons' ? 'archived-persons' : 'users'
-	);
+	const activeTab = $derived.by(() => {
+		const tab = page.url.searchParams.get('tab');
+		return tab === 'archived-persons' || tab === 'api-keys' ? tab : 'users';
+	});
 
 	async function switchTab(tab: string) {
 		const url = new URL(page.url);
@@ -23,17 +34,56 @@
 		}
 		await goto(url.toString(), { replaceState: true, noScroll: true, keepFocus: true });
 	}
+
+	let revealedKey = $state<string | null>(null);
+
+	// svelte-ignore state_referenced_locally
+	const { form, errors, enhance, submitting } = superForm(data.createApiKeyForm, {
+		id: 'createApiKey',
+		dataType: 'json',
+		resetForm: true,
+		onUpdate: ({ form, result }) => {
+			if (form.message?.type === 'success') {
+				toast.success(form.message.text);
+				const resultData = result.data as { apiKey?: string } | undefined;
+				revealedKey = resultData?.apiKey ?? null;
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
+			}
+		},
+		onError: ({ result }) => {
+			toast.error(`Failed to create API key: ${result.error.message}`);
+		}
+	});
+
+	function toggleScope(scope: ApiScope, checked: boolean) {
+		if (checked) {
+			if (!$form.scopes.includes(scope)) {
+				$form.scopes = [...$form.scopes, scope];
+			}
+		} else {
+			$form.scopes = $form.scopes.filter((s) => s !== scope);
+		}
+	}
+
+	async function copyRevealedKey() {
+		if (!revealedKey) return;
+		await navigator.clipboard.writeText(revealedKey);
+		toast.success('Copied to clipboard.');
+	}
 </script>
 
 <PageShell class="min-w-0 overflow-x-hidden">
 	<div class="mb-4 sm:mb-5">
 		<h1 class="font-display text-2xl font-bold sm:text-3xl">Admin</h1>
-		<p class="text-muted-foreground text-sm sm:text-base">Manage users and archived contacts</p>
+		<p class="text-muted-foreground text-sm sm:text-base">
+			Manage users, archived contacts, and API keys
+		</p>
 	</div>
 
 	<Tabs.Root value={activeTab} class="w-full gap-3">
 		<Tabs.List
-			class="bg-muted/75 text-muted-foreground grid h-11 w-full grid-cols-2 rounded-xl p-1"
+			class="bg-muted/75 text-muted-foreground grid h-11 w-full grid-cols-3 rounded-xl p-1"
 		>
 			<Tabs.Trigger
 				value="users"
@@ -53,6 +103,15 @@
 			>
 				Archived Persons
 			</Tabs.Trigger>
+			<Tabs.Trigger
+				value="api-keys"
+				class="font-display border-b-2 border-transparent data-[state=active]:border-red-500"
+				onclick={() => {
+					if (activeTab !== 'api-keys') void switchTab('api-keys');
+				}}
+			>
+				API Keys
+			</Tabs.Trigger>
 		</Tabs.List>
 
 		<Tabs.Content value="users" class="mt-0 w-full space-y-4">
@@ -61,6 +120,109 @@
 
 		<Tabs.Content value="archived-persons" class="mt-0 w-full space-y-4">
 			<AdminArchivedPersonsTable people={data.archivedPeople} />
+		</Tabs.Content>
+
+		<Tabs.Content value="api-keys" class="mt-0 w-full space-y-4">
+			<p class="text-muted-foreground text-sm">
+				Keys for external tools (e.g. scripts or assistants) to drive Synapse via the
+				<code class="bg-muted rounded px-1 py-0.5">/api/v1</code> API.
+			</p>
+
+			{#if revealedKey}
+				<Card class="border-amber-300 bg-amber-50 dark:border-amber-500/30 dark:bg-amber-950">
+					<CardHeader>
+						<CardTitle class="text-amber-900 dark:text-amber-200">
+							Copy your new API key now
+						</CardTitle>
+					</CardHeader>
+					<CardContent class="space-y-2">
+						<p class="text-sm text-amber-900 dark:text-amber-200">
+							This is the only time this key will be shown. Store it somewhere safe.
+						</p>
+						<div class="flex gap-2">
+							<Input
+								readonly
+								value={revealedKey}
+								class="border-amber-300 bg-white font-mono text-sm text-amber-950 dark:border-amber-500/30 dark:bg-amber-900 dark:text-amber-100"
+							/>
+							<Button type="button" variant="outline" onclick={copyRevealedKey}>
+								<CopyIcon class="size-4" />
+								Copy
+							</Button>
+						</div>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							class="text-amber-900 dark:text-amber-200"
+							onclick={() => (revealedKey = null)}
+						>
+							Done
+						</Button>
+					</CardContent>
+				</Card>
+			{/if}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Create a new key</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<form method="POST" action="?/createApiKey" use:enhance class="space-y-4">
+						<div>
+							<Label for="key-name" class="mb-2 block">Name</Label>
+							<Input
+								id="key-name"
+								name="name"
+								bind:value={$form.name}
+								placeholder="e.g. Personal assistant, script, etc."
+								class={$errors.name ? 'border-destructive' : ''}
+							/>
+							{#if $errors.name}
+								<p class="text-destructive mt-1 text-sm">{$errors.name}</p>
+							{/if}
+						</div>
+
+						<div>
+							<span class="mb-2 block text-sm font-medium">Scopes</span>
+							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+								{#each API_SCOPES as scope (scope)}
+									<label class="flex items-center gap-2 text-sm">
+										<Checkbox
+											checked={$form.scopes.includes(scope)}
+											onCheckedChange={(checked) => toggleScope(scope, Boolean(checked))}
+										/>
+										{scope}
+									</label>
+								{/each}
+							</div>
+							{#if $errors.scopes}
+								<p class="text-destructive mt-1 text-sm">{$errors.scopes}</p>
+							{/if}
+						</div>
+
+						<div>
+							<Label for="key-expires" class="mb-2 block">Expires in (days, optional)</Label>
+							<Input
+								id="key-expires"
+								name="expiresInDays"
+								type="number"
+								min="1"
+								max="365"
+								bind:value={$form.expiresInDays}
+								placeholder="Never expires"
+								class="max-w-40"
+							/>
+						</div>
+
+						<Button type="submit" disabled={$submitting}>
+							{$submitting ? 'Creating...' : 'Create key'}
+						</Button>
+					</form>
+				</CardContent>
+			</Card>
+
+			<AdminApiKeysTable apiKeys={data.apiKeys} />
 		</Tabs.Content>
 	</Tabs.Root>
 </PageShell>

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { API_SCOPES, type ApiScope } from '$lib/api-scopes';
 	import AdminApiKeysTable from '$lib/components/admin/AdminApiKeysTable.svelte';
+	import AdminApiLogsTable from '$lib/components/admin/AdminApiLogsTable.svelte';
 	import AdminArchivedPersonsTable from '$lib/components/admin/AdminArchivedPersonsTable.svelte';
 	import AdminUsersTable from '$lib/components/admin/AdminUsersTable.svelte';
 	import PageShell from '$lib/components/app/PageShell.svelte';
@@ -22,7 +23,7 @@
 
 	const activeTab = $derived.by(() => {
 		const tab = page.url.searchParams.get('tab');
-		return tab === 'archived-persons' || tab === 'api-keys' ? tab : 'users';
+		return tab === 'archived-persons' || tab === 'api-keys' || tab === 'api-logs' ? tab : 'users';
 	});
 
 	async function switchTab(tab: string) {
@@ -83,7 +84,7 @@
 
 	<Tabs.Root value={activeTab} class="w-full gap-3">
 		<Tabs.List
-			class="bg-muted/75 text-muted-foreground grid h-11 w-full grid-cols-3 rounded-xl p-1"
+			class="bg-muted/75 text-muted-foreground grid h-11 w-full grid-cols-4 rounded-xl p-1"
 		>
 			<Tabs.Trigger
 				value="users"
@@ -111,6 +112,15 @@
 				}}
 			>
 				API Keys
+			</Tabs.Trigger>
+			<Tabs.Trigger
+				value="api-logs"
+				class="font-display border-b-2 border-transparent data-[state=active]:border-red-500"
+				onclick={() => {
+					if (activeTab !== 'api-logs') void switchTab('api-logs');
+				}}
+			>
+				API Logs
 			</Tabs.Trigger>
 		</Tabs.List>
 
@@ -223,6 +233,13 @@
 			</Card>
 
 			<AdminApiKeysTable apiKeys={data.apiKeys} />
+		</Tabs.Content>
+
+		<Tabs.Content value="api-logs" class="mt-0 w-full space-y-4">
+			<p class="text-muted-foreground text-sm">
+				Audit trail of write actions taken via the external API.
+			</p>
+			<AdminApiLogsTable entries={data.apiLogs} />
 		</Tabs.Content>
 	</Tabs.Root>
 </PageShell>

--- a/src/routes/(app)/fitness/+page.server.ts
+++ b/src/routes/(app)/fitness/+page.server.ts
@@ -639,9 +639,12 @@ export const actions = {
 				}
 			}
 
-			await db.transaction(async (tx) => {
-				await tx
-					.update(workoutLogs)
+			// The better-sqlite3 driver runs transaction callbacks synchronously, so every
+			// query inside must use its sync execution method (`.run()`) instead of `await`
+			// — an `async` callback throws "Transaction function cannot return a promise"
+			// at runtime.
+			db.transaction((tx) => {
+				tx.update(workoutLogs)
 					.set({
 						date: form.data.date,
 						time: form.data.time || null,
@@ -651,22 +654,25 @@ export const actions = {
 						notes: form.data.notes || null,
 						...withAuditFieldsForUpdate()
 					})
-					.where(and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id)));
+					.where(and(eq(workoutLogs.id, form.data.id), eq(workoutLogs.userId, user.id)))
+					.run();
 
-				await tx.delete(workoutExercises).where(eq(workoutExercises.workoutLogId, form.data.id));
+				tx.delete(workoutExercises).where(eq(workoutExercises.workoutLogId, form.data.id)).run();
 
 				if (form.data.type === 'strength' && parsedExercises.length > 0) {
-					await tx.insert(workoutExercises).values(
-						parsedExercises.map((exercise) => ({
-							id: generateId(),
-							workoutLogId: form.data.id,
-							exerciseName: exercise.exerciseName,
-							sets: exercise.sets || null,
-							reps: exercise.reps || null,
-							weightLbs: exercise.weightLbs || null,
-							...withAuditFieldsForCreate()
-						}))
-					);
+					tx.insert(workoutExercises)
+						.values(
+							parsedExercises.map((exercise) => ({
+								id: generateId(),
+								workoutLogId: form.data.id,
+								exerciseName: exercise.exerciseName,
+								sets: exercise.sets || null,
+								reps: exercise.reps || null,
+								weightLbs: exercise.weightLbs || null,
+								...withAuditFieldsForCreate()
+							}))
+						)
+						.run();
 				}
 			});
 

--- a/src/routes/(app)/tasks/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/tasks/[id]/edit/+page.server.ts
@@ -124,19 +124,26 @@ export const actions = {
 			} else {
 				const timestamp = new Date().toISOString();
 
-				await getDb().transaction(async (tx) => {
-					const [targetSortOrderRow] = await tx
+				// The better-sqlite3 driver runs transaction callbacks synchronously, so every
+				// query inside must use its sync execution method (`.all()`/`.run()`/`.sync()`)
+				// instead of `await` — an `async` callback throws "Transaction function cannot
+				// return a promise" at runtime.
+				getDb().transaction((tx) => {
+					const [targetSortOrderRow] = tx
 						.select({
 							maxSortOrder: sql<number>`coalesce(max(${tasks.sortOrder}), -1)`
 						})
 						.from(tasks)
-						.where(and(eq(tasks.userId, user.id), eq(tasks.state, nextState)));
+						.where(and(eq(tasks.userId, user.id), eq(tasks.state, nextState)))
+						.all();
 
-					const sourceRows = await tx.query.tasks.findMany({
-						where: and(eq(tasks.userId, user.id), eq(tasks.state, existing.state as TaskState)),
-						columns: { id: true },
-						orderBy: [tasks.sortOrder, tasks.taskNumber]
-					});
+					const sourceRows = tx.query.tasks
+						.findMany({
+							where: and(eq(tasks.userId, user.id), eq(tasks.state, existing.state as TaskState)),
+							columns: { id: true },
+							orderBy: [tasks.sortOrder, tasks.taskNumber]
+						})
+						.sync();
 
 					const sourceTaskIds = sourceRows
 						.map((row) => row.id)
@@ -150,23 +157,23 @@ export const actions = {
 						existing.state
 					);
 
-					await tx
-						.update(tasks)
+					tx.update(tasks)
 						.set({
 							...updateData,
 							sortOrder: (targetSortOrderRow?.maxSortOrder ?? -1) + 1,
 							updatedAt: timestamp
 						})
-						.where(and(eq(tasks.id, taskId), eq(tasks.userId, user.id)));
+						.where(and(eq(tasks.id, taskId), eq(tasks.userId, user.id)))
+						.run();
 
 					for (let index = 0; index < sourceTaskIds.length; index += 1) {
-						await tx
-							.update(tasks)
+						tx.update(tasks)
 							.set({
 								sortOrder: index,
 								updatedAt: timestamp
 							})
-							.where(and(eq(tasks.id, sourceTaskIds[index]), eq(tasks.userId, user.id)));
+							.where(and(eq(tasks.id, sourceTaskIds[index]), eq(tasks.userId, user.id)))
+							.run();
 					}
 				});
 			}

--- a/src/routes/api/v1/meals/+server.ts
+++ b/src/routes/api/v1/meals/+server.ts
@@ -1,0 +1,71 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiCreateMealSchema, apiMealListQuerySchema } from '$lib/server/api/schemas/meals';
+import { getDb } from '$lib/server/db';
+import { mealLogs } from '$lib/server/db/schema';
+import { createMeal } from '$lib/server/db/writes/meals';
+import { logger } from '$lib/server/logger';
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'meals:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiMealListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	const { startDate, endDate, timeOfDay, limit } = parsed.data;
+
+	try {
+		const conditions = [eq(mealLogs.userId, auth.userId)];
+		if (startDate && endDate) {
+			conditions.push(gte(mealLogs.date, startDate), lte(mealLogs.date, endDate));
+		}
+		if (timeOfDay) conditions.push(eq(mealLogs.timeOfDay, timeOfDay));
+
+		const results = await getDb().query.mealLogs.findMany({
+			where: and(...conditions),
+			orderBy: [desc(mealLogs.date)],
+			limit
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list meals', error);
+		return apiError('internal_error', 'Failed to load meals.', 500);
+	}
+};
+
+export const POST: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'meals:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiCreateMealSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'POST',
+			path: url.pathname,
+			action: 'meals:write'
+		},
+		() => createMeal(auth.userId, parsed.data),
+		{ successStatus: 201, failureMessage: 'Failed to create meal' }
+	);
+};

--- a/src/routes/api/v1/meals/[id]/+server.ts
+++ b/src/routes/api/v1/meals/[id]/+server.ts
@@ -1,0 +1,60 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiUpdateMealSchema } from '$lib/server/api/schemas/meals';
+import { getDb } from '$lib/server/db';
+import { mealLogs } from '$lib/server/db/schema';
+import { updateMeal } from '$lib/server/db/writes/meals';
+import { logger } from '$lib/server/logger';
+import { and, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, params }) => {
+	const auth = await requireApiKey(request, 'meals:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	try {
+		const meal = await getDb().query.mealLogs.findFirst({
+			where: and(eq(mealLogs.id, params.id), eq(mealLogs.userId, auth.userId))
+		});
+
+		if (!meal) {
+			return apiError('not_found', 'Meal not found.', 404);
+		}
+
+		return apiSuccess(meal);
+	} catch (error) {
+		logger.error('API: failed to load meal', error);
+		return apiError('internal_error', 'Failed to load meal.', 500);
+	}
+};
+
+export const PATCH: RequestHandler = async ({ request, params, url }) => {
+	const auth = await requireApiKey(request, 'meals:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiUpdateMealSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'PATCH',
+			path: url.pathname,
+			action: 'meals:write'
+		},
+		() => updateMeal(auth.userId, params.id, parsed.data),
+		{ successStatus: 200, failureMessage: 'Failed to update meal' }
+	);
+};

--- a/src/routes/api/v1/mood/+server.ts
+++ b/src/routes/api/v1/mood/+server.ts
@@ -1,0 +1,69 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiMoodListQuerySchema, apiUpsertMoodSchema } from '$lib/server/api/schemas/mood';
+import { getDb } from '$lib/server/db';
+import { moodLogs } from '$lib/server/db/schema';
+import { upsertMood } from '$lib/server/db/writes/mood';
+import { logger } from '$lib/server/logger';
+import { and, asc, eq, gte, lte } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'mood:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiMoodListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	const { startDate, endDate } = parsed.data;
+
+	try {
+		const conditions = [eq(moodLogs.userId, auth.userId)];
+		if (startDate && endDate) {
+			conditions.push(gte(moodLogs.date, startDate), lte(moodLogs.date, endDate));
+		}
+
+		const results = await getDb().query.moodLogs.findMany({
+			where: and(...conditions),
+			orderBy: [asc(moodLogs.date)]
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list mood logs', error);
+		return apiError('internal_error', 'Failed to load mood logs.', 500);
+	}
+};
+
+export const POST: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'mood:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiUpsertMoodSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'POST',
+			path: url.pathname,
+			action: 'mood:write'
+		},
+		() => upsertMood(auth.userId, parsed.data),
+		{ successStatus: 200, failureMessage: 'Failed to save mood log' }
+	);
+};

--- a/src/routes/api/v1/people/+server.ts
+++ b/src/routes/api/v1/people/+server.ts
@@ -1,0 +1,37 @@
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiPeopleListQuerySchema } from '$lib/server/api/schemas/people';
+import { getDb } from '$lib/server/db';
+import { people } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logger';
+import { and, asc, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'people:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiPeopleListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	try {
+		const conditions = [eq(people.userId, auth.userId)];
+		if (!parsed.data.includeArchived) {
+			conditions.push(eq(people.isArchived, false));
+		}
+
+		const results = await getDb().query.people.findMany({
+			where: and(...conditions),
+			orderBy: [asc(people.name)],
+			columns: { id: true, name: true, isArchived: true, scheduledVisitDate: true }
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list people', error);
+		return apiError('internal_error', 'Failed to load people.', 500);
+	}
+};

--- a/src/routes/api/v1/tasks/+server.ts
+++ b/src/routes/api/v1/tasks/+server.ts
@@ -1,0 +1,69 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiCreateTaskSchema, apiTaskListQuerySchema } from '$lib/server/api/schemas/tasks';
+import { getDb } from '$lib/server/db';
+import { tasks } from '$lib/server/db/schema';
+import { createTask } from '$lib/server/db/writes/tasks';
+import { logger } from '$lib/server/logger';
+import { and, desc, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'tasks:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiTaskListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	const { state, priority, limit } = parsed.data;
+
+	try {
+		const conditions = [eq(tasks.userId, auth.userId)];
+		if (state) conditions.push(eq(tasks.state, state));
+		if (priority) conditions.push(eq(tasks.priority, priority));
+
+		const results = await getDb().query.tasks.findMany({
+			where: and(...conditions),
+			orderBy: [desc(tasks.createdAt)],
+			limit
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list tasks', error);
+		return apiError('internal_error', 'Failed to load tasks.', 500);
+	}
+};
+
+export const POST: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'tasks:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiCreateTaskSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'POST',
+			path: url.pathname,
+			action: 'tasks:write'
+		},
+		() => createTask(auth.userId, parsed.data),
+		{ successStatus: 201, failureMessage: 'Failed to create task' }
+	);
+};

--- a/src/routes/api/v1/tasks/[id]/+server.ts
+++ b/src/routes/api/v1/tasks/[id]/+server.ts
@@ -1,0 +1,60 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiUpdateTaskSchema } from '$lib/server/api/schemas/tasks';
+import { getDb } from '$lib/server/db';
+import { tasks } from '$lib/server/db/schema';
+import { updateTask } from '$lib/server/db/writes/tasks';
+import { logger } from '$lib/server/logger';
+import { and, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, params }) => {
+	const auth = await requireApiKey(request, 'tasks:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	try {
+		const task = await getDb().query.tasks.findFirst({
+			where: and(eq(tasks.id, params.id), eq(tasks.userId, auth.userId))
+		});
+
+		if (!task) {
+			return apiError('not_found', 'Task not found.', 404);
+		}
+
+		return apiSuccess(task);
+	} catch (error) {
+		logger.error('API: failed to load task', error);
+		return apiError('internal_error', 'Failed to load task.', 500);
+	}
+};
+
+export const PATCH: RequestHandler = async ({ request, params, url }) => {
+	const auth = await requireApiKey(request, 'tasks:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiUpdateTaskSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'PATCH',
+			path: url.pathname,
+			action: 'tasks:write'
+		},
+		() => updateTask(auth.userId, params.id, parsed.data),
+		{ successStatus: 200, failureMessage: 'Failed to update task' }
+	);
+};

--- a/src/routes/api/v1/visits/+server.ts
+++ b/src/routes/api/v1/visits/+server.ts
@@ -1,0 +1,68 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiCreateVisitSchema, apiVisitListQuerySchema } from '$lib/server/api/schemas/visits';
+import { getDb } from '$lib/server/db';
+import { visits } from '$lib/server/db/schema';
+import { createVisit } from '$lib/server/db/writes/visits';
+import { logger } from '$lib/server/logger';
+import { and, desc, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'visits:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiVisitListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	const { personId, limit } = parsed.data;
+
+	try {
+		const conditions = [eq(visits.userId, auth.userId)];
+		if (personId) conditions.push(eq(visits.personId, personId));
+
+		const results = await getDb().query.visits.findMany({
+			where: and(...conditions),
+			orderBy: [desc(visits.date)],
+			limit
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list visits', error);
+		return apiError('internal_error', 'Failed to load visits.', 500);
+	}
+};
+
+export const POST: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'visits:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiCreateVisitSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'POST',
+			path: url.pathname,
+			action: 'visits:write'
+		},
+		() => createVisit(auth.userId, parsed.data),
+		{ successStatus: 201, failureMessage: 'Failed to create visit' }
+	);
+};

--- a/src/routes/api/v1/visits/[id]/+server.ts
+++ b/src/routes/api/v1/visits/[id]/+server.ts
@@ -1,0 +1,60 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiUpdateVisitSchema } from '$lib/server/api/schemas/visits';
+import { getDb } from '$lib/server/db';
+import { visits } from '$lib/server/db/schema';
+import { updateVisit } from '$lib/server/db/writes/visits';
+import { logger } from '$lib/server/logger';
+import { and, eq } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, params }) => {
+	const auth = await requireApiKey(request, 'visits:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	try {
+		const visit = await getDb().query.visits.findFirst({
+			where: and(eq(visits.id, params.id), eq(visits.userId, auth.userId))
+		});
+
+		if (!visit) {
+			return apiError('not_found', 'Visit not found.', 404);
+		}
+
+		return apiSuccess(visit);
+	} catch (error) {
+		logger.error('API: failed to load visit', error);
+		return apiError('internal_error', 'Failed to load visit.', 500);
+	}
+};
+
+export const PATCH: RequestHandler = async ({ request, params, url }) => {
+	const auth = await requireApiKey(request, 'visits:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiUpdateVisitSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'PATCH',
+			path: url.pathname,
+			action: 'visits:write'
+		},
+		() => updateVisit(auth.userId, params.id, parsed.data),
+		{ successStatus: 200, failureMessage: 'Failed to update visit' }
+	);
+};

--- a/src/routes/api/v1/workouts/+server.ts
+++ b/src/routes/api/v1/workouts/+server.ts
@@ -1,0 +1,74 @@
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import {
+	apiCreateWorkoutSchema,
+	apiWorkoutListQuerySchema
+} from '$lib/server/api/schemas/workouts';
+import { getDb } from '$lib/server/db';
+import { workoutLogs } from '$lib/server/db/schema';
+import { createWorkout } from '$lib/server/db/writes/workouts';
+import { logger } from '$lib/server/logger';
+import { and, desc, eq, gte, lte } from 'drizzle-orm';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'workouts:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	const parsed = apiWorkoutListQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	const { startDate, endDate, type, limit } = parsed.data;
+
+	try {
+		const conditions = [eq(workoutLogs.userId, auth.userId)];
+		if (startDate && endDate) {
+			conditions.push(gte(workoutLogs.date, startDate), lte(workoutLogs.date, endDate));
+		}
+		if (type) conditions.push(eq(workoutLogs.type, type));
+
+		const results = await getDb().query.workoutLogs.findMany({
+			where: and(...conditions),
+			orderBy: [desc(workoutLogs.date)],
+			limit
+		});
+
+		return apiSuccess(results);
+	} catch (error) {
+		logger.error('API: failed to list workouts', error);
+		return apiError('internal_error', 'Failed to load workouts.', 500);
+	}
+};
+
+export const POST: RequestHandler = async ({ request, url }) => {
+	const auth = await requireApiKey(request, 'workouts:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiCreateWorkoutSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'POST',
+			path: url.pathname,
+			action: 'workouts:write'
+		},
+		() => createWorkout(auth.userId, parsed.data),
+		{ successStatus: 201, failureMessage: 'Failed to create workout' }
+	);
+};

--- a/src/routes/api/v1/workouts/[id]/+server.ts
+++ b/src/routes/api/v1/workouts/[id]/+server.ts
@@ -1,0 +1,54 @@
+import { ApiWriteError } from '$lib/server/api/errors';
+import { handleApiWrite } from '$lib/server/api/handle-write';
+import { requireApiKey } from '$lib/server/api/require-api-key';
+import { apiError, apiSuccess } from '$lib/server/api/response';
+import { apiUpdateWorkoutSchema } from '$lib/server/api/schemas/workouts';
+import { getWorkoutWithExercises, updateWorkout } from '$lib/server/db/writes/workouts';
+import { logger } from '$lib/server/logger';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request, params }) => {
+	const auth = await requireApiKey(request, 'workouts:read');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	try {
+		const workout = await getWorkoutWithExercises(auth.userId, params.id);
+		return apiSuccess(workout);
+	} catch (error) {
+		if (error instanceof ApiWriteError) {
+			return apiError(error.code, error.message, error.status);
+		}
+		logger.error('API: failed to load workout', error);
+		return apiError('internal_error', 'Failed to load workout.', 500);
+	}
+};
+
+export const PATCH: RequestHandler = async ({ request, params, url }) => {
+	const auth = await requireApiKey(request, 'workouts:write');
+	if (!auth.ok) return apiError(auth.code, auth.message, auth.status);
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return apiError('invalid_json', 'Request body must be valid JSON.', 400);
+	}
+
+	const parsed = apiUpdateWorkoutSchema.safeParse(body);
+	if (!parsed.success) {
+		return apiError('validation_failed', parsed.error.issues.map((i) => i.message).join('; '), 400);
+	}
+
+	return handleApiWrite(
+		{
+			apiKeyId: auth.apiKeyId,
+			userId: auth.userId,
+			method: 'PATCH',
+			path: url.pathname,
+			action: 'workouts:write'
+		},
+		() => updateWorkout(auth.userId, params.id, parsed.data),
+		{ successStatus: 200, failureMessage: 'Failed to update workout' }
+	);
+};


### PR DESCRIPTION
## Summary

- Adds an `/api/v1` JSON API authenticated with API keys, so tasks, mood, workouts, meals, and visits can be created/updated/listed from outside the web UI (a script, an assistant, etc.) — mirroring the architecture already used by `sheppakai-budget`'s transactions API.
- New `@better-auth/api-key` plugin wiring (`apikey`/`api_audit_log` tables, migration `0024`), per-key scopes (`src/lib/api-scopes.ts`), a `{ data }` / `{ error: { code, message } }` response envelope, and an audit log of every write (`api_audit_log`).
- Routes: `tasks` (GET/POST + `[id]` GET/PATCH), `mood` (GET/POST upsert — mood is one-per-day), `workouts` (GET/POST + `[id]` GET/PATCH, with exercises), `meals` (GET/POST + `[id]` GET/PATCH), `visits` (GET/POST + `[id]` GET/PATCH), and a read-only `people` endpoint so a `personId` can be resolved externally for the visits endpoints.
- New **Admin → API Keys** tab (alongside the existing Users / Archived Persons tabs) to create keys (name, scopes, optional expiry) and revoke them; the plaintext key is shown once, at creation.
- New `docs/API.md` documenting auth, scopes, response/error shapes, and one `curl` example per endpoint.
- Each new write path (`src/lib/server/db/writes/*.ts`) is deliberately kept separate from the existing UI's superforms actions rather than sharing code, mirroring budget's `db/writes/transactions.ts` — same reasoning: the narrower API write path can't regress the tested UI actions.

## Incidental fix

While building the task/workout update paths, found that the equivalent existing UI actions (`tasks/[id]/edit/+page.server.ts`'s state-change resort, `fitness/+page.server.ts`'s `updateWorkout`) used an `async` callback inside a `better-sqlite3` `db.transaction()`, which throws `"Transaction function cannot return a promise"` at runtime — better-sqlite3 requires transaction callbacks to be synchronous. Fixed all four occurrences (two new, two pre-existing) by switching to sync execution (`.all()`/`.run()`/`.sync()`) inside the transaction callback.

## Test plan

- [x] `npm run check`, `npm run lint`, `npm run fmt:check` all pass
- [x] `npm run test` — 436 tests pass, including new coverage for the auth/response/audit-log plumbing and every new API schema
- [x] Manually exercised every endpoint against the dev server with `curl` using a real API key created through `auth.api.createApiKey` (create/update/get/list for tasks, workouts, meals, visits; upsert/list for mood; list for people), confirming success shapes, scope enforcement (401 on a key without the required scope), validation failures, invalid JSON, 404s, and that the audit log recorded each write — then cleaned up all test data from the dev DB afterward
- [ ] Admin → API Keys tab itself needs a manual look in the browser — Claude in Chrome wasn't connected in this session, so the UI (create form, reveal-once key card, table, revoke dialog) is implemented and type-checked but not visually verified

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbZXq5dWeENMk1QHBavKPs